### PR TITLE
feat(components): update browser targets to support :has()

### DIFF
--- a/docs/0-welcome.mdx
+++ b/docs/0-welcome.mdx
@@ -54,4 +54,4 @@ export default function App() {
 
 ## Browser Support
 
-[Check compatible browsers](https://browsersl.ist/#q=defaults+and+supports+es6-module%2C%0A++++chrome+%3E+88%2C%0A++++safari+%3E+14%2C%0A++++firefox+%3E+78%2C%0A++++opera+%3E+75%2C%0A++++edge+%3E+88)
+[Check compatible browsers](https://browsersl.ist/#q=defaults+and+supports+es6-module%2C%0A++++chrome+%3E+105%2C%0A++++safari+%3E+15.4%2C%0A++++firefox+%3E+121%2C%0A++++opera+%3E+91%2C%0A++++edge+%3E+105)

--- a/package.json
+++ b/package.json
@@ -170,11 +170,11 @@
   },
   "browserslist": [
     "defaults and supports es6-module",
-    "chrome > 88",
-    "safari > 14",
-    "firefox > 78",
-    "opera > 75",
-    "edge > 88"
+    "chrome > 105",
+    "safari > 15.4",
+    "firefox > 121",
+    "opera > 91",
+    "edge > 105"
   ],
   "packageManager": "pnpm@9.12.2"
 }


### PR DESCRIPTION
This PR updates browser versions so we can use **:has()**. 

Motivation:

**It helps write cleaner CSS and reduces the need for extra JavaScript.
Modern browsers support it, so it's a good time to upgrade!**

For reference:
- [Can I use :has()](https://caniuse.com/css-has)
- [MDN Docs on :has()](https://developer.mozilla.org/en-US/docs/Web/CSS/:has)

Browser Support:
- [Check compatible browsers](https://browsersl.ist/#q=defaults+and+supports+es6-module%2C%0A++++chrome+%3E+105%2C%0A++++safari+%3E+15.4%2C%0A++++firefox+%3E+121%2C%0A++++opera+%3E+91%2C%0A++++edge+%3E+105)