### PR TITLE
feat(components/Tooltip): add support for `portalContainer`

### DIFF
--- a/packages/components/src/components/Tooltip/Tooltip.mdx
+++ b/packages/components/src/components/Tooltip/Tooltip.mdx
@@ -103,3 +103,9 @@ anchor element whereas the `crossOffset` prop handles the spacing applied along 
 The open state of the tooltip can be controlled via the `defaultOpen` and `open` props.
 
 <Story of={Stories.ControlledOpen} />
+
+## Portal container
+
+Use `portalContainer` prop to determine the target DOM node for overlay rendering.
+
+<Story of={Stories.PortalContainer} />

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -390,3 +390,36 @@ export const Offsets: Story = {
     );
   },
 };
+
+export const PortalContainer: Story = {
+  name: 'Portal container',
+  render: function Render(args: TooltipProps) {
+    const [container, setContainer] = useState<HTMLDivElement | null>(null);
+
+    return (
+      <div
+        ref={setContainer}
+        style={{
+          width: 100,
+          height: 100,
+          display: 'flex',
+          position: 'relative',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {container && (
+          <Tooltip
+            portalContainer={container}
+            control={() => (
+              <Button variant="fade-contrast-filled">Hover me</Button>
+            )}
+            {...args}
+          >
+            Tooltip
+          </Tooltip>
+        )}
+      </div>
+    );
+  },
+};

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -40,6 +40,7 @@ export const Tooltip = forwardRef<TooltipRef, TooltipProps>((props, ref) => {
     open: openProp,
     offset: offsetProp,
     arrowBoundaryOffset,
+    portalContainer,
     ...other
   } = props;
 
@@ -111,7 +112,7 @@ export const Tooltip = forwardRef<TooltipRef, TooltipProps>((props, ref) => {
         appear
       >
         {(transition) => (
-          <Overlay>
+          <Overlay portalContainer={portalContainer}>
             <div
               {...mergeProps(localTooltipProps, tooltipProps)}
               data-arrow={showArrow}

--- a/packages/components/src/components/Tooltip/types.ts
+++ b/packages/components/src/components/Tooltip/types.ts
@@ -1,10 +1,10 @@
 import type {
+  Ref,
+  RefObject,
   ReactNode,
   ComponentRef,
-  Ref,
   ReactElement,
   HTMLAttributes,
-  RefObject,
 } from 'react';
 
 import type { DataAttributeProps } from '@koobiq/react-core';
@@ -110,6 +110,11 @@ export type TooltipProps = {
   id?: string;
   /** Additional CSS-classes. */
   className?: string;
+  /**
+   * The container element in which the component portal will be placed.
+   * @default document.body
+   */
+  portalContainer?: Element;
 } & DataAttributeProps;
 
 export type TooltipRef = ComponentRef<'div'>;


### PR DESCRIPTION
Adds support for the `portalContainer` prop to control where overlays are rendered.