### PR TITLE
fix(components/Tooltip): extend and generalize types for the `control` prop

### DIFF
--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -411,9 +411,7 @@ export const PortalContainer: Story = {
         {container && (
           <Tooltip
             portalContainer={container}
-            control={() => (
-              <Button variant="fade-contrast-filled">Hover me</Button>
-            )}
+            control={(props) => <Typography {...props}>Hover me</Typography>}
             {...args}
           >
             Tooltip

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   mergeProps,
   useBoolean,
   FocusableProvider,
+  useMultiRef,
 } from '@koobiq/react-core';
 import {
   Overlay,
@@ -59,7 +60,8 @@ export const Tooltip = forwardRef<TooltipRef, TooltipProps>((props, ref) => {
   });
 
   const domRef = useDOMRef<ComponentRef<'div'>>(ref);
-  const controlRef = useRef<HTMLButtonElement | null>(null);
+  const controlRef = useRef<HTMLElement | null>(null);
+  const controlRefCallback = useMultiRef([controlRef]);
 
   const { triggerProps, tooltipProps } = useTooltipTrigger(
     {
@@ -97,7 +99,7 @@ export const Tooltip = forwardRef<TooltipRef, TooltipProps>((props, ref) => {
     <>
       <FocusableProvider {...triggerProps} ref={controlRef}>
         {control?.({
-          ref: controlRef,
+          ref: controlRefCallback,
           ...triggerProps,
         })}
       </FocusableProvider>

--- a/packages/components/src/components/Tooltip/types.ts
+++ b/packages/components/src/components/Tooltip/types.ts
@@ -1,16 +1,17 @@
 import type {
-  Ref,
-  RefObject,
   ReactNode,
+  RefObject,
   ComponentRef,
   ReactElement,
-  HTMLAttributes,
+  DOMAttributes,
 } from 'react';
 
 import type { DataAttributeProps } from '@koobiq/react-core';
 
 export type TooltipPropControl = (
-  props: HTMLAttributes<HTMLButtonElement> & { ref?: Ref<HTMLButtonElement> }
+  props: DOMAttributes<HTMLElement> & {
+    ref: ((node: HTMLElement | null) => void) | null;
+  }
 ) => ReactElement;
 
 export const tooltipPropPlacement = [


### PR DESCRIPTION
Fixes the `control` prop types to support any HTML element without type errors.