### PR TITLE
fix(components): restore lost `style.css` during migration to Vite 6

### DIFF
--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       entry: path.resolve(__dirname, 'src/index.ts'),
       fileName: (_, entryName: string) => `${entryName}.js`,
       formats: ['es'],
+      cssFileName: 'style',
     },
     minify: false,
     target: browserslistToEsbuild(browserslist(browsers)),


### PR DESCRIPTION
See details: https://vite.dev/guide/migration.html#customize-css-output-file-name-in-library-mode