### PR TITLE
feat(components/Provider): add `breakpointsFallback` to support SSR fallback for breakpoints

### DIFF
--- a/docs/3-responsive-ui.mdx
+++ b/docs/3-responsive-ui.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/blocks';
+import { Alert } from '../.storybook/components';
 
 <Meta title="Responsive UI" />
 
@@ -27,6 +28,31 @@ The `Provider` component helps you manage responsive breakpoints in your app.
 
 - Wrap the application with the `Provider` component to enable responsive breakpoints.
 - Access the breakpoints object from the `useBreakpoints` hook in your component.
+
+### Server-Side Rendering
+
+<Alert status="warning">
+  Server-side rendering and client-side media queries are fundamentally at odds.
+  Be aware of the tradeoff. The support can only be partial.
+</Alert>
+
+Use `breakpointsFallback` on the server because media queries can't run without a real screen.
+It provides default values for breakpoints during server-side rendering to ensure consistent UI on first load.
+
+You can set values for `breakpointsFallback` using the userAgent, for example to check if it's a phone or a desktop.
+But this gives only a basic idea of the device. If you need more accurate results, it's better to use
+[CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
+
+```tsx
+import { Provider } from '@koobiq/react-components';
+
+const App = () => (
+  // On the server, all breakpoints up to size "l" will be considered active
+  <Provider breakpointsFallback={[true, true, true, true]}>
+    My application
+  </Provider>
+);
+```
 
 ### Example
 

--- a/packages/components/src/components/Provider/BreakpointsProvider.tsx
+++ b/packages/components/src/components/Provider/BreakpointsProvider.tsx
@@ -9,13 +9,21 @@ import { useBreakpoints } from './utils';
 export type BreakpointsProviderProps = {
   children: ReactNode;
   breakpoints: Breakpoints;
+  defaultMatches?: boolean[];
 };
 
 export const BreakpointsProvider = ({
   children,
+  defaultMatches,
   breakpoints: _breakpoints,
 }: BreakpointsProviderProps) => {
-  const breakpoints = useBreakpoints(_breakpoints);
+  const breakpoints = useBreakpoints(
+    _breakpoints,
+    defaultMatches && {
+      ssr: true,
+      defaultMatches,
+    }
+  );
 
   return (
     <BreakpointsContext.Provider value={breakpoints}>

--- a/packages/components/src/components/Provider/Provider.tsx
+++ b/packages/components/src/components/Provider/Provider.tsx
@@ -17,12 +17,16 @@ export const defaultBreakpoints: Breakpoints = {
 
 export const Provider = ({
   breakpoints = defaultBreakpoints,
+  breakpointsFallback,
   children,
   locale,
 }: ProviderProps) => (
   <ProviderContext.Provider value={{ breakpoints, locale }}>
     <I18nProvider locale={locale}>
-      <BreakpointsProvider breakpoints={breakpoints}>
+      <BreakpointsProvider
+        breakpoints={breakpoints}
+        defaultMatches={breakpointsFallback}
+      >
         {children}
       </BreakpointsProvider>
     </I18nProvider>

--- a/packages/components/src/components/Provider/types.ts
+++ b/packages/components/src/components/Provider/types.ts
@@ -13,7 +13,12 @@ export type Breakpoints = {
 };
 
 export type ProviderProps = {
+  /** The content of the component. */
   children?: ReactNode;
+  /** Responsive breakpoints for your application. */
   breakpoints?: Breakpoints;
+  /** SSR-fallback for responsive breakpoints for your application. */
+  breakpointsFallback?: boolean[];
+  /** The locale for your application as a [BCP 47](https://www.ietf.org/rfc/bcp/bcp47.txt) language code. Defaults to the browser/OS language setting. */
   locale?: I18nProviderProps['locale'];
 };

--- a/packages/components/src/components/Provider/utils/useBreakpoints.ts
+++ b/packages/components/src/components/Provider/utils/useBreakpoints.ts
@@ -1,15 +1,19 @@
 'use client';
 
 import { useMediaQuery } from '@koobiq/react-core';
+import type { UseMediaQueryOptions } from '@koobiq/react-core';
 
 import type { Breakpoints } from '../types';
 
-export function useBreakpoints(breakpoints: Breakpoints) {
+export function useBreakpoints(
+  breakpoints: Breakpoints,
+  options?: UseMediaQueryOptions
+) {
   const queries = Object.values(breakpoints).map(
     (width) => `(min-width: ${width}px)`
   );
 
-  const matches = useMediaQuery(queries);
+  const matches = useMediaQuery(queries, options);
 
   return Object.keys(breakpoints).reduce(
     (acc, item, index) => ({ ...acc, [item]: matches[index] }),


### PR DESCRIPTION
Motivation:

Use `breakpointsFallback` on the server because media queries can't run without a real screen.
It provides default values for breakpoints during server-side rendering to ensure consistent UI on first load.

You can set values for `breakpointsFallback` using the userAgent, for example to check if it's a phone or a desktop.
But this gives only a basic idea of the device. If you need more accurate results, it's better to use
[CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).

```tsx
import { Provider } from '@koobiq/react-components';

const App = () => (
  // On the server, all breakpoints up to size "l" will be considered active
  <Provider breakpointsFallback={[true, true, true, true]}>
    My application
  </Provider>
);