### PR TITLE
fix(Tooltip/Popover): adapt anchorRef typing for React 19

### DIFF
--- a/packages/components/src/components/Popover/types.ts
+++ b/packages/components/src/components/Popover/types.ts
@@ -88,7 +88,7 @@ export type PopoverProps = {
    * */
   placement?: PopoverPropPlacement;
   /** The ref for the element which the popover positions itself with respect to. */
-  anchorRef?: RefObject<HTMLElement>;
+  anchorRef?: RefObject<HTMLElement | null>;
   /**
    * If `true`, the arrow isn't shown.
    * @default false

--- a/packages/components/src/components/Tooltip/types.ts
+++ b/packages/components/src/components/Tooltip/types.ts
@@ -68,7 +68,7 @@ export type TooltipProps = {
    * */
   placement?: TooltipPropPlacement;
   /** The ref for the element which the popover positions itself with respect to. */
-  anchorRef?: RefObject<HTMLElement>;
+  anchorRef?: RefObject<HTMLElement | null>;
   /**
    * The minimum distance the arrow's edge should be from the edge of the overlay element.
    * @default 0


### PR DESCRIPTION
Fix a type error related to different types for `RefObject`:

```ts
// React 18
interface RefObject<T> {
    current: T | null;
}
```

```ts
// Reac 19
interface RefObject<T> {
    current: T;
}
```

See details:
https://medium.com/%40ignatovich.dm/the-new-approach-to-passing-refs-in-react-19-typescript-a5762b938b93
https://react.dev/blog/2024/04/25/react-19-upgrade-guide?utm_source=chatgpt.com#useref-requires-argument