### PR TITLE
Fix and improve `Link`

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -212,8 +212,8 @@
   :is(a:not(.sb-anchor, .sb-unstyled, .sb-unstyled a, [aria-hidden='true'])) {
     transition: color 0ms;
     border: none;
-    color: var(--kbq-foreground-theme);
     text-decoration: underline;
+    color: var(--kbq-foreground-theme);
     text-decoration-color: var(--kbq-line-theme-less);
     text-underline-offset: calc((var(--kbq-md-typography-md-body-line-height) - var(--kbq-md-typography-md-body-font-size)) / 2);
     font-size: var(--kbq-md-typography-md-body-font-size);

--- a/packages/components/src/components/Link/Link.module.css
+++ b/packages/components/src/components/Link/Link.module.css
@@ -5,17 +5,22 @@
   --link-outline-width: var(--kbq-size-3xs);
   padding: 0;
   border: none;
-  outline: none;
   cursor: pointer;
   background: none;
-  transition: color 0ms;
   text-decoration: underline;
   color: var(--kbq-foreground-theme);
+  outline: var(--link-outline-width) solid;
+  outline-color: transparent;
   text-decoration-color: var(--kbq-line-theme-less);
+  transition:
+    color var(--kbq-transition-default),
+    outline var(--kbq-transition-default),
+    text-decoration-color var(--kbq-transition-default);
 
   &[aria-disabled='true'] {
     cursor: not-allowed;
     text-decoration: none;
+    outline-color: transparent;
     color: var(--kbq-states-foreground-disabled);
     text-decoration-color: var(--kbq-states-line-disabled);
   }
@@ -33,6 +38,7 @@
 
 .focusVisible {
   color: var(--kbq-foreground-theme);
+  outline-color: var(--kbq-states-line-focus-theme);
   text-decoration-color: var(--kbq-line-theme-less);
 }
 
@@ -51,13 +57,9 @@
   text-decoration-color: var(--kbq-line-visited);
 }
 
-.pseudo:where(:not(.pressed, .hovered)) {
-  text-decoration: none;
-}
-
-.pseudo:where(.focusVisible) {
-  outline: var(--link-outline-width) solid var(--kbq-states-line-focus-theme);
-  outline-offset: -1px;
+.pseudo:where(:not(.pressed, .hovered)),
+.pseudo[aria-disabled='true'] {
+  text-decoration-color: transparent;
 }
 
 .hasIcon {

--- a/packages/components/src/components/Link/Link.stories.tsx
+++ b/packages/components/src/components/Link/Link.stories.tsx
@@ -45,7 +45,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Base: Story = {
   render: (args: LinkBaseProps) => (
-    <Link href="#" {...args}>
+    <Link href="https://react.koobiq.io" target="_blank" {...args}>
       Link
     </Link>
   ),

--- a/packages/components/src/components/Link/Link.test.tsx
+++ b/packages/components/src/components/Link/Link.test.tsx
@@ -33,6 +33,28 @@ describe('Link', () => {
     expect(screen.getByText(baseProps.children)).toBeInTheDocument();
   });
 
+  it('should be blocked when in a disabled state', async () => {
+    const props = {
+      ...baseProps,
+      onClick: vi.fn(),
+      href: '#',
+      disabled: true,
+    };
+
+    render(<Link {...props} />);
+
+    const link = getRoot();
+
+    await userEvent.tab();
+
+    expect(link).not.toHaveFocus();
+
+    await userEvent.click(link);
+
+    expect(props.onClick).toHaveBeenCalledTimes(0);
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
   describe('button', () => {
     it('should be like a button with as=button', async () => {
       const props = {

--- a/packages/components/src/components/Link/Link.test.tsx
+++ b/packages/components/src/components/Link/Link.test.tsx
@@ -4,7 +4,7 @@ import { screen, render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 
-import { Link } from './index.js';
+import { Link } from './Link';
 
 describe('Link', () => {
   const baseProps = {

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -31,6 +31,7 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
       as={as}
       disabled={disabled}
       elementType={elementType}
+      {...(disabled && { tabIndex: -1 })}
       className={({ hovered, pressed, focusVisible }) =>
         clsx(
           s.base,

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import type { ComponentPropsWithRef, ComponentRef, ElementType } from 'react';
+import type { ComponentPropsWithRef, ElementType } from 'react';
 
-import { clsx, useDOMRef, polymorphicForwardRef } from '@koobiq/react-core';
-import { useLink } from '@koobiq/react-primitives';
+import { clsx, polymorphicForwardRef } from '@koobiq/react-core';
+import { Link as LinkPrimitive } from '@koobiq/react-primitives';
 
 import s from './Link.module.css';
 import type { LinkBaseProps } from './types';
@@ -13,48 +13,44 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
     variant = 'text-normal',
     visitable = false,
     pseudo = false,
+    disabled,
     as = 'a',
     startIcon,
     endIcon,
     children,
     className,
-    style,
+    ...other
   } = props;
-
-  const Tag = as;
-
-  const domRef = useDOMRef<ComponentRef<'a'>>(ref);
-
-  const elementType = as !== 'a' && as !== 'button' ? `${as}` : undefined;
-
-  const { linkProps, hovered, pressed, focusVisible } = useLink(
-    { ...props, elementType },
-    domRef
-  );
 
   const hasIcon = Boolean(startIcon || endIcon);
 
+  const elementType = as !== 'a' && as !== 'button' ? `${as}` : undefined;
+
   return (
-    <Tag
-      {...linkProps}
-      className={clsx(
-        s.base,
-        s[variant],
-        pseudo && s.pseudo,
-        hovered && s.hovered,
-        pressed && s.pressed,
-        hasIcon && s.hasIcon,
-        visitable && s.visitable,
-        focusVisible && s.focusVisible,
-        className
-      )}
-      style={style}
-      ref={domRef}
+    <LinkPrimitive
+      as={as}
+      disabled={disabled}
+      elementType={elementType}
+      className={({ hovered, pressed, focusVisible }) =>
+        clsx(
+          s.base,
+          s[variant],
+          pseudo && s.pseudo,
+          hovered && s.hovered,
+          pressed && s.pressed,
+          hasIcon && s.hasIcon,
+          visitable && s.visitable,
+          focusVisible && s.focusVisible,
+          className
+        )
+      }
+      {...other}
+      ref={ref}
     >
       {startIcon}
       {children}
       {endIcon}
-    </Tag>
+    </LinkPrimitive>
   );
 });
 

--- a/packages/primitives/src/components/Link/Link.tsx
+++ b/packages/primitives/src/components/Link/Link.tsx
@@ -37,7 +37,11 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
   });
 
   return (
-    <Tag {...mergeProps(linkProps, renderProps)} ref={ref}>
+    <Tag
+      {...mergeProps(linkProps, renderProps)}
+      tabIndex={props.tabIndex || linkProps.tabIndex}
+      ref={domRef}
+    >
       {renderProps.children}
     </Tag>
   );

--- a/packages/primitives/src/components/Link/types.ts
+++ b/packages/primitives/src/components/Link/types.ts
@@ -12,6 +12,6 @@ export type LinkRenderProps = {
 };
 
 export type LinkBaseProps = ExtendableProps<
-  RenderProps<LinkRenderProps>,
+  RenderProps<LinkRenderProps> & { tabIndex?: number },
   UseLinkProps
 >;


### PR DESCRIPTION
- add outline for focus-visible state
- support custom tabIndex in LinkPrimitive
- migrate to LinkPrimitive
- fix: prevent focus when disabled