### PR TITLE
docs: add GitHub repository links

### DIFF
--- a/.storybook/themes.ts
+++ b/.storybook/themes.ts
@@ -2,7 +2,8 @@ import { create } from '@storybook/theming';
 
 export const brand = {
   brandTitle: 'Koobiq React',
-  brandTarget: '_self',
+  brandUrl: 'https://github.com/koobiq/react-components',
+  brandTarget: '_blank',
   fontBase:
     "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;", // var(--kbq-font-family-base)
   fontCode:

--- a/docs/0-welcome.mdx
+++ b/docs/0-welcome.mdx
@@ -9,7 +9,7 @@ import {
 
 # Koobiq React
 
-<Version />
+[![Version](https://img.shields.io/npm/v/@koobiq/react-components)](https://www.npmjs.com/package/@koobiq/react-components) [![Stars](https://img.shields.io/github/stars/koobiq/react-components?style=social)](https://github.com/koobiq/react-components/)
 
 **Koobiq React is an open-source design system for designers and developers, focused on designing products related to information security**.
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "directory": "packages/components",
+    "url": "git+https://github.com/koobiq/react-components.git"
+  },
   "sideEffects": false,
   "dependencies": {
     "@koobiq/design-tokens": "^3.12.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "directory": "packages/core",
+    "url": "git+https://github.com/koobiq/react-components.git"
+  },
   "sideEffects": false,
   "dependencies": {
     "@react-aria/focus": "^3.18.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,6 +17,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "directory": "packages/icons",
+    "url": "git+https://github.com/koobiq/react-components.git"
+  },
   "scripts": {
     "clean": "rimraf dist && rimraf node_modules && rimraf .turbo",
     "clean:temp": "rimraf temp && rimraf src",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,6 +16,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "directory": "packages/logger",
+    "url": "git+https://github.com/koobiq/react-components.git"
+  },
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -16,6 +16,11 @@
       "default": "./dist/index.js"
     }
   },
+  "repository": {
+    "type": "git",
+    "directory": "packages/primitives",
+    "url": "git+https://github.com/koobiq/react-components.git"
+  },
   "type": "module",
   "files": ["dist"],
   "publishConfig": {


### PR DESCRIPTION
- add shields.io badges for npm version and github repository
- make project logo point to GitHub repo
- include links to github repos on npm pages