### PR TITLE
fix(components/Modal): handle horizontal scrolling in dialog window

### DIFF
--- a/packages/components/src/components/Dialog/Dialog.module.css
+++ b/packages/components/src/components/Dialog/Dialog.module.css
@@ -3,6 +3,7 @@
   flex-grow: 1;
   outline: none;
   display: flex;
+  overflow: hidden;
   position: relative;
   min-block-size: 48px;
   pointer-events: auto;


### PR DESCRIPTION
<img width="192" alt="Снимок экрана 2025-05-21 в 10 43 01" src="https://github.com/user-attachments/assets/7b2a7e11-f334-4ef7-acb1-94c1732a7cda" />
