### PR TITLE
fix(Button): correct disabled border color in outline variants (DS-5384)

### DIFF
--- a/packages/components/src/components/Button/Button.module.css
+++ b/packages/components/src/components/Button/Button.module.css
@@ -79,13 +79,6 @@
   cursor: default;
 }
 
-.disabled {
-  --button-border-color: var(--button-border-color-disabled);
-
-  color: var(--button-color-disabled);
-  background-color: var(--button-bg-color-disabled);
-}
-
 .fullWidth {
   inline-size: 100%;
 }
@@ -193,6 +186,13 @@
   --button-bg-color-hover: var(--kbq-states-background-transparent-hover);
   --button-bg-color-active: var(--kbq-states-background-transparent-active);
   --button-bg-color-disabled: var(--kbq-background-transparent);
+}
+
+.disabled {
+  --button-border-color: var(--button-border-color-disabled);
+
+  color: var(--button-color-disabled);
+  background-color: var(--button-bg-color-disabled);
 }
 
 .focusVisible {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the styling order for disabled buttons to ensure disabled colors are applied consistently alongside theme-transparent variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->