### PR TITLE
docs(storybook): fix blank content in Safari (DS-5437)

### DIFF
--- a/.storybook/components/DocContainer.tsx
+++ b/.storybook/components/DocContainer.tsx
@@ -1,15 +1,11 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext } from 'react';
 
 import { Provider } from '@koobiq/react-components';
-import { isNotNil } from '@koobiq/react-core';
 import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks';
 import { linkTo } from '@storybook/addon-links';
-import { DARK_MODE_EVENT_NAME } from '@vueless/storybook-dark-mode';
-import { addons } from 'storybook/preview-api';
+import { useDarkMode } from '@vueless/storybook-dark-mode';
 
 import { light, dark } from '../themes';
-
-const channel = addons.getChannel();
 
 export const ThemeProviderContext = createContext<{
   isDark?: boolean;
@@ -19,18 +15,7 @@ export const useThemeProvider = () => useContext(ThemeProviderContext);
 
 export const DocContainer: typeof BaseContainer = (params) => {
   const { context, children } = params;
-  const [isDark, setDark] = useState();
-  const themeIsMounted = isNotNil(isDark);
-
-  useEffect(() => {
-    channel.on(DARK_MODE_EVENT_NAME, setDark);
-
-    return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
-  }, [channel, setDark]);
-
-  if (!themeIsMounted) {
-    return null;
-  }
+  const isDark = useDarkMode();
 
   return (
     <BaseContainer context={context} theme={isDark ? dark : light}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dark-mode handling in the documentation interface.
  * Removed the temporary loading state, allowing documentation content to render immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->