### PR TITLE
chore(ci): pass PR title to commitlint via env

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,10 +2,15 @@ name: Commitlint
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-node
-      - run: echo "${{ github.event.pull_request.title }}" | pnpm commitlint --verbose
+      - run: printf '%s\n' "$PR_TITLE" | pnpm commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - run: printf '%s\n' "$PR_TITLE" | pnpm commitlint --verbose
         env:


### PR DESCRIPTION
### Проблема

`${{ github.event.pull_request.title }}` подставлялся прямо в текст скрипта шага `run:`, поэтому bash разбирал заголовок PR как код. Заголовок с бэктиками ронял проверку — bash пытался выполнить слово внутри них.

Это script injection: заголовок задаёт любой, кто открывает PR. Влияние ограничено — триггер `pull_request`, а не `pull_request_target`, так что форковые запуски идут без секретов и с read-only токеном.

### Что сделано

- заголовок передаётся через `env:` — bash не перечитывает значение переменной как код
- `printf '%s\n'` вместо `echo`: последний съедает заголовок, равный ровно `-n` или `-e`
- добавлен `permissions: contents: read`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request title validation reliability.
  * Strengthened automated workflow security by limiting repository access to read-only content and preventing credential persistence during validation.
  * Standardized title handling to ensure special characters and formatting are processed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->