### PR TITLE
fix(Link): correct semantics with as="button" (DS-5436)

### DIFF
--- a/packages/components/src/components/Link/Link.module.css
+++ b/packages/components/src/components/Link/Link.module.css
@@ -18,6 +18,7 @@
     outline var(--kbq-transition-default),
     text-decoration-color var(--kbq-transition-default);
 
+  &[data-disabled],
   &[aria-disabled='true'] {
     cursor: default;
     text-decoration: none;
@@ -59,6 +60,7 @@
 }
 
 .pseudo:where(:not(.pressed, .hovered)),
+.pseudo[data-disabled],
 .pseudo[aria-disabled='true'] {
   text-decoration-color: transparent;
 }

--- a/packages/components/src/components/Link/Link.test.tsx
+++ b/packages/components/src/components/Link/Link.test.tsx
@@ -58,6 +58,16 @@ describe('Link', () => {
   });
 
   describe('button', () => {
+    it('should accept the ref', () => {
+      const ref = createRef<HTMLButtonElement>();
+
+      const { container } = render(
+        <Link {...baseProps} as="button" ref={ref} />
+      );
+
+      expect(ref.current).toBe(container.querySelector('button'));
+    });
+
     it('should be like a button with as=button', async () => {
       const props = {
         ...baseProps,
@@ -72,6 +82,104 @@ describe('Link', () => {
       await userEvent.click(linkAsButton);
 
       expect(props.onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have button semantics instead of role=link', () => {
+      render(<Link {...baseProps} as="button" />);
+
+      expect(getRoot()).not.toHaveAttribute('role');
+      expect(screen.getByRole('button', { name: 'link' })).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should keep the visual styles of the link', () => {
+      const { rerender, container } = render(<Link {...baseProps} href="#" />);
+      const linkClassName = container.querySelector('a')?.className;
+
+      rerender(<Link {...baseProps} as="button" />);
+
+      expect(container.querySelector('button')).toHaveClass(
+        String(linkClassName)
+      );
+    });
+
+    it('should not submit the enclosing form by default', async () => {
+      const onSubmit = vi.fn((event) => event.preventDefault());
+
+      render(
+        <form onSubmit={onSubmit}>
+          <Link {...baseProps} as="button" />
+        </form>
+      );
+
+      expect(getRoot()).toHaveAttribute('type', 'button');
+
+      await userEvent.click(getRoot());
+
+      expect(onSubmit).toHaveBeenCalledTimes(0);
+    });
+
+    it('should submit the enclosing form with type=submit', async () => {
+      const onSubmit = vi.fn((event) => event.preventDefault());
+
+      render(
+        <form onSubmit={onSubmit}>
+          <Link {...baseProps} as="button" type="submit" />
+        </form>
+      );
+
+      expect(getRoot()).toHaveAttribute('type', 'submit');
+
+      await userEvent.click(getRoot());
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward button HTML props', () => {
+      render(
+        <>
+          <form id="form-id" />
+          <Link
+            {...baseProps}
+            as="button"
+            form="form-id"
+            name="action"
+            value="save"
+            formNoValidate
+            formMethod="post"
+            formTarget="_blank"
+          />
+        </>
+      );
+
+      const linkAsButton = getRoot();
+
+      expect(linkAsButton).toHaveAttribute('form', 'form-id');
+      expect(linkAsButton).toHaveAttribute('name', 'action');
+      expect(linkAsButton).toHaveAttribute('value', 'save');
+      expect(linkAsButton).toHaveAttribute('formnovalidate');
+      expect(linkAsButton).toHaveAttribute('formmethod', 'post');
+      expect(linkAsButton).toHaveAttribute('formtarget', '_blank');
+    });
+
+    it('should forward button ARIA props', () => {
+      render(
+        <Link
+          {...baseProps}
+          as="button"
+          aria-expanded
+          aria-pressed
+          aria-haspopup="menu"
+          aria-controls="panel-id"
+        />
+      );
+
+      const linkAsButton = getRoot();
+
+      expect(linkAsButton).toHaveAttribute('aria-expanded', 'true');
+      expect(linkAsButton).toHaveAttribute('aria-pressed', 'true');
+      expect(linkAsButton).toHaveAttribute('aria-haspopup', 'menu');
+      expect(linkAsButton).toHaveAttribute('aria-controls', 'panel-id');
     });
 
     it('should be blocked, unfocused, non-clickable, and have correct accessibility attributes when in a disabled state', async () => {
@@ -92,7 +200,8 @@ describe('Link', () => {
       await userEvent.click(linkAsButton);
 
       expect(props.onPress).toHaveBeenCalledTimes(0);
-      expect(linkAsButton).toHaveAttribute('aria-disabled', 'true');
+      expect(linkAsButton).toBeDisabled();
+      expect(linkAsButton).toHaveAttribute('data-disabled');
     });
   });
 

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentPropsWithRef, ElementType } from 'react';
 
-import { deprecate } from '@koobiq/logger';
+import { deprecate, once } from '@koobiq/logger';
 import { clsx, polymorphicForwardRef } from '@koobiq/react-core';
 import { Link as LinkPrimitive } from '@koobiq/react-primitives';
 
@@ -34,6 +34,8 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
   const isDisabled = isDisabledProp ?? disabled;
   const isPseudo = isPseudoProp ?? pseudo;
 
+  const isButton = as === 'button';
+
   const hasIcon = Boolean(startIcon || endIcon);
 
   if (process.env.NODE_ENV !== 'production' && 'visitable' in props) {
@@ -54,11 +56,17 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
     );
   }
 
+  if (process.env.NODE_ENV !== 'production' && isButton && 'href' in props) {
+    once.warn(
+      'Link: the "href" prop is ignored with as="button". Keep the default anchor for navigation, or handle the action with "onPress".'
+    );
+  }
+
   return (
     <LinkPrimitive
       as={as}
       isDisabled={isDisabled}
-      {...(isDisabled && { tabIndex: -1 })}
+      {...(isDisabled && !isButton && { tabIndex: -1 })}
       className={({ isHovered, isPressed, isFocusVisible }) =>
         clsx(
           s.base,

--- a/packages/components/src/components/TimeRange/TimeRange.test.tsx
+++ b/packages/components/src/components/TimeRange/TimeRange.test.tsx
@@ -541,7 +541,7 @@ describe('TimeRange', () => {
 
       const control = screen.getByRole('button', { name: 'Period' });
       expect(ref.current).toBe(control);
-      await userEvent.click(screen.getByRole('link', { name: 'Help' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Help' }));
       await userEvent.click(screen.getByRole('button', { name: 'Action' }));
       expect(onPress).toHaveBeenCalledTimes(2);
       expect(queryDialog()).not.toBeInTheDocument();

--- a/packages/primitives/src/components/Link/Link.mdx
+++ b/packages/primitives/src/components/Link/Link.mdx
@@ -82,11 +82,17 @@ const MyLink = () => (
 The Link component is a semantic anchor by default.
 If you need button-like behavior, render it as a button via `as="button"` and handle actions with `onPress`.
 
+In this mode the element is announced as a button (no `role="link"`), `type` defaults
+to `button`, `isDisabled` sets the native `disabled` attribute, and button HTML and
+ARIA props (`form`, `name`, `value`, `aria-expanded`, `aria-controls`, `aria-haspopup`,
+`aria-pressed`) reach the DOM. `href` is ignored — keep the anchor for navigation.
+
 <Story of={Stories.Button} />
 
 ## Disabled
 
 Use `isDisabled` to make the link non-interactive. It prevents navigation by removing `href`
-and removes press/click handlers to avoid accidental activation.
+and removes press/click handlers to avoid accidental activation. With `as="button"`
+the native `disabled` attribute is used instead.
 
 <Story of={Stories.Disabled} />

--- a/packages/primitives/src/components/Link/Link.stories.tsx
+++ b/packages/primitives/src/components/Link/Link.stories.tsx
@@ -62,7 +62,12 @@ export const Base = (args: LinkProps) => (
 
 export const Button = {
   render: Base,
-  args: { children: 'Button', as: 'button', onPress: () => alert('Press!') },
+  args: {
+    href: undefined,
+    children: 'Button',
+    as: 'button',
+    onPress: () => alert('Press!'),
+  },
 };
 
 export const Disabled = {

--- a/packages/primitives/src/components/Link/Link.tsx
+++ b/packages/primitives/src/components/Link/Link.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import type { ComponentPropsWithRef, ComponentRef, ElementType } from 'react';
+import type {
+  ComponentPropsWithRef,
+  ComponentRef,
+  ElementType,
+  ForwardedRef,
+} from 'react';
 
 import {
   useObjectRef,
@@ -10,25 +15,76 @@ import {
 } from '@koobiq/react-core';
 import { useRenderProps } from 'react-aria-components';
 
-import { useLink } from '../../behaviors';
+import { useButton, useLink } from '../../behaviors';
 
-import type { LinkBaseProps } from './types.js';
+import type { LinkBaseProps, LinkRenderProps } from './types.js';
 
-/**
- * A link primitive allows a user to navigate to another page or resource within
- * a web page or application.
- */
-export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
-  const { as: Tag = 'a', ...other } = props;
+type LinkInnerProps<E extends HTMLElement> = LinkBaseProps & {
+  elementRef: ForwardedRef<E>;
+};
 
-  const domRef = useObjectRef<ComponentRef<'a'>>(ref);
+const useCommonProps = (props: LinkBaseProps, values: LinkRenderProps) => {
+  const renderProps = useRenderProps({ ...props, values });
+
+  const DOMProps = filterDOMProps(props, { global: true });
+
+  delete DOMProps.onClick;
+
+  return {
+    DOMProps,
+    renderProps,
+    stateProps: {
+      'data-hovered': values.isHovered || undefined,
+      'data-pressed': values.isPressed || undefined,
+      'data-focused': values.isFocused || undefined,
+      'data-disabled': values.isDisabled || undefined,
+      'data-focus-visible': values.isFocusVisible || undefined,
+    },
+  };
+};
+
+const LinkAsButton = ({
+  elementRef,
+  ...props
+}: LinkInnerProps<HTMLButtonElement>) => {
+  const domRef = useObjectRef<ComponentRef<'button'>>(elementRef);
+
+  const { isHovered, isPressed, isFocused, isFocusVisible, buttonProps } =
+    useButton<'button'>({ ...props, elementType: 'button' }, domRef);
+
+  const { DOMProps, renderProps, stateProps } = useCommonProps(props, {
+    isHovered,
+    isPressed,
+    isFocused,
+    isFocusVisible,
+    isDisabled: props.isDisabled || false,
+  });
+
+  return (
+    <button
+      {...stateProps}
+      {...mergeProps(DOMProps, renderProps, buttonProps)}
+      {...('tabIndex' in props && { tabIndex: props.tabIndex })}
+      ref={domRef}
+    >
+      {renderProps.children}
+    </button>
+  );
+};
+
+const LinkAsAnchor = ({
+  as: Tag = 'a',
+  elementRef,
+  ...props
+}: LinkInnerProps<HTMLAnchorElement> & { as?: ElementType }) => {
+  const domRef = useObjectRef<ComponentRef<'a'>>(elementRef);
 
   const { isHovered, isPressed, isFocusVisible, isFocused, linkProps } =
     useLink(
       {
-        ...other,
+        ...props,
         elementType: `${Tag}`,
-        ...(other.isDisabled && {
+        ...(props.isDisabled && {
           onPress: undefined,
           onPressStart: undefined,
           onPressEnd: undefined,
@@ -43,29 +99,17 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
       domRef
     );
 
-  const renderValues = {
+  const { DOMProps, renderProps, stateProps } = useCommonProps(props, {
     isHovered,
     isPressed,
     isFocused,
     isFocusVisible,
     isDisabled: props.isDisabled || false,
-  };
-
-  const renderProps = useRenderProps({
-    ...props,
-    values: renderValues,
   });
-
-  const DOMProps = filterDOMProps(props, { global: true });
-  delete DOMProps.onClick;
 
   return (
     <Tag
-      data-hovered={isHovered || undefined}
-      data-pressed={isPressed || undefined}
-      data-focused={isFocused || undefined}
-      data-disabled={props.isDisabled || undefined}
-      data-focus-visible={isFocusVisible || undefined}
+      {...stateProps}
       {...mergeProps(DOMProps, renderProps, linkProps)}
       {...('tabIndex' in props && { tabIndex: props.tabIndex })}
       ref={domRef}
@@ -73,7 +117,21 @@ export const Link = polymorphicForwardRef<'a', LinkBaseProps>((props, ref) => {
       {renderProps.children}
     </Tag>
   );
-});
+};
+
+/**
+ * A link primitive allows a user to navigate to another page or resource within
+ * a web page or application. With `as="button"` it switches to button semantics
+ * instead of a button driven by link interactions.
+ */
+export const Link = polymorphicForwardRef<'a', LinkBaseProps>(
+  ({ as, ...props }, ref) =>
+    as === 'button' ? (
+      <LinkAsButton {...props} elementRef={ref} />
+    ) : (
+      <LinkAsAnchor {...props} as={as} elementRef={ref} />
+    )
+);
 
 export type LinkProps<As extends ElementType = 'a'> = ComponentPropsWithRef<
   typeof Link<As>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Link` components rendered with `as="button"` now use native button semantics and support standard button and ARIA properties.
  * Button links default to `type="button"`, forward refs, and map disabled state to the native `disabled` attribute.
  * Anchor and button rendering now provide distinct interaction and keyboard behavior.

* **Documentation**
  * Added guidance clarifying button rendering, disabled behavior, and handling of `href`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->