### PR TITLE
fix(Tabs): prevent tab list from shrinking in Safari (DS-5500)

### DIFF
--- a/packages/components/src/components/Tabs/Tabs.module.css
+++ b/packages/components/src/components/Tabs/Tabs.module.css
@@ -70,6 +70,11 @@
 .horizontal {
   flex-direction: column;
 
+  &:not(.stretched) .tabList {
+    /* Keep the clipped list at its content width in Safari. */
+    flex-shrink: 0;
+  }
+
   &[data-horizontal-scrollable] {
     .scrollBox {
       cursor: grab;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved horizontal tab layouts in Safari by keeping non-stretched tab lists at their content width, preventing unwanted shrinking when clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->