### PR TITLE
feat(TreeSelect): add renderTag prop (DS-5277)

### DIFF
--- a/packages/components/src/components/TreeSelect/TreeSelect.mdx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.mdx
@@ -117,7 +117,7 @@ or `selectedTagsOverflow="multiline"` to wrap tags onto multiple lines.
 
 ### Custom tag render
 
-Use `renderTag` to customize selected tags.
+Use `renderTag` to customize tags in multiple selection mode.
 
 <Story of={Stories.CustomTagRender} />
 

--- a/packages/components/src/components/TreeSelect/TreeSelect.mdx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.mdx
@@ -115,6 +115,12 @@ or `selectedTagsOverflow="multiline"` to wrap tags onto multiple lines.
 
 <Story of={Stories.SelectedTagsOverflow} />
 
+### Custom tag render
+
+Use `renderTag` to customize selected tags.
+
+<Story of={Stories.CustomTagRender} />
+
 ### Disabled
 
 When TreeSelect is disabled, it cannot be interacted with.

--- a/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     'TreeSelect.Tag': TreeSelect.Tag,
   },
   argTypes: {},
-  tags: ['status:new', 'date:2026-06-26'],
+  tags: ['status:updated', 'date:2026-09-07'],
 } satisfies Meta<typeof TreeSelect>;
 
 export default meta;

--- a/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { type Key, useBoolean } from '@koobiq/react-core';
-import { IconCrosshairs16 } from '@koobiq/react-icons';
+import { IconCrosshairs16, IconFolder16 } from '@koobiq/react-icons';
 import { Collection } from '@koobiq/react-primitives';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -23,6 +23,7 @@ const meta = {
     'TreeSelect.Item': TreeSelect.Item,
     'TreeSelect.ItemContent': TreeSelect.ItemContent,
     'TreeSelect.LoadMoreItem': TreeSelect.LoadMoreItem,
+    'TreeSelect.Tag': TreeSelect.Tag,
   },
   argTypes: {},
   tags: ['status:new', 'date:2026-06-26'],
@@ -447,6 +448,55 @@ export const SelectedTagsOverflow: Story = {
           }}
         </TreeSelect>
       </FlexBox>
+    );
+  },
+};
+
+export const CustomTagRender: Story = {
+  render: function Render() {
+    type FileNode = {
+      id: number;
+      title: string;
+      children: FileNode[];
+    };
+
+    const items: FileNode[] = [
+      {
+        id: 1,
+        title: 'app',
+        children: [{ id: 2, title: 'Http', children: [] }],
+      },
+      { id: 3, title: 'config', children: [] },
+      { id: 4, title: 'public', children: [] },
+    ];
+
+    return (
+      <TreeSelect
+        items={items}
+        label="Project folders"
+        selectionMode="multiple"
+        style={{ inlineSize: 320 }}
+        placeholder="Select folders"
+        defaultValue={[2, 3]}
+        renderTag={(item, tagProps) => (
+          <TreeSelect.Tag
+            {...tagProps}
+            variant="warning-fade"
+            icon={<IconFolder16 />}
+          >
+            {item.textValue}
+          </TreeSelect.Tag>
+        )}
+      >
+        {function renderItem(item) {
+          return (
+            <TreeSelect.Item id={item.id} textValue={item.title}>
+              <TreeSelect.ItemContent>{item.title}</TreeSelect.ItemContent>
+              <Collection items={item.children}>{renderItem}</Collection>
+            </TreeSelect.Item>
+          );
+        }}
+      </TreeSelect>
     );
   },
 };

--- a/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
@@ -369,6 +369,24 @@ describe('TreeSelect', () => {
   });
 
   describe('renderTag', () => {
+    const getTag = (key: number) => screen.getByTestId(`tag-${key}`);
+    const queryTag = (key: number) => screen.queryByTestId(`tag-${key}`);
+
+    const getRemoveButton = (key: number) =>
+      within(getTag(key)).getByRole('button', { hidden: true });
+
+    const renderTag: NonNullable<
+      TreeSelectProps<FileNode, 'multiple'>['renderTag']
+    > = (item, tagProps) => (
+      <TreeSelect.Tag
+        {...tagProps}
+        icon={<span data-testid={`tag-icon-${item.key}`} />}
+        data-testid={`tag-${item.key}`}
+      >
+        {item.textValue}
+      </TreeSelect.Tag>
+    );
+
     it('should ignore renderTag in single selection mode', () => {
       const renderTag = vi.fn(() => <div>Custom tag</div>);
 
@@ -381,6 +399,44 @@ describe('TreeSelect', () => {
     describe.each(['responsive', 'multiline'] as const)(
       '%s overflow',
       (selectedTagsOverflow) => {
+        it('should support custom elements and forward props for overflow measurement', () => {
+          const renderCustomTag = vi.fn<
+            NonNullable<TreeSelectProps<FileNode, 'multiple'>['renderTag']>
+          >((item, { className, ref, 'aria-hidden': ariaHidden }) => (
+            <div
+              ref={ref}
+              className={className}
+              aria-hidden={ariaHidden}
+              data-testid={`tag-${item.key}`}
+            >
+              Custom: {item.textValue}
+            </div>
+          ));
+
+          renderTreeSelect({
+            selectionMode: 'multiple',
+            defaultValue: [2, 7],
+            selectedTagsOverflow,
+            renderTag: renderCustomTag,
+          });
+
+          expect(getTag(2)).toHaveTextContent('Custom: Http');
+          expect(getTag(7)).toHaveTextContent('Custom: README.md');
+
+          const tagProps = renderCustomTag.mock.calls
+            .filter(([item]) => item.key === 2)
+            .at(-1)?.[1];
+
+          expect(tagProps?.className).toEqual(expect.any(String));
+          expect(getTag(2)).toHaveClass(tagProps!.className!);
+
+          if (selectedTagsOverflow === 'responsive') {
+            expect(tagProps?.ref).toEqual(
+              expect.objectContaining({ current: getTag(2) })
+            );
+          }
+        });
+
         it('should customize tags using selected items, including collapsed descendants', () => {
           renderTreeSelect({
             selectionMode: 'multiple',
@@ -397,18 +453,27 @@ describe('TreeSelect', () => {
             ),
           });
 
-          expect(screen.getByTestId('tag-2')).toHaveTextContent('File: Http');
+          expect(getTag(2)).toHaveTextContent('File: Http');
 
-          expect(screen.getByTestId('tag-7')).toHaveTextContent(
-            'File: README.md'
-          );
+          expect(getTag(7)).toHaveTextContent('File: README.md');
 
-          expect(screen.getByTestId('tag-2')).toHaveAttribute(
-            'data-variant',
-            'warning-fade'
-          );
+          expect(getTag(2)).toHaveAttribute('data-variant', 'warning-fade');
 
-          expect(screen.queryByTestId('tag-1')).not.toBeInTheDocument();
+          expect(queryTag(1)).not.toBeInTheDocument();
+        });
+
+        it('should preserve invalid styling when customizing tag content', () => {
+          renderTreeSelect({
+            selectionMode: 'multiple',
+            defaultValue: [7],
+            selectedTagsOverflow,
+            isInvalid: true,
+            renderTag,
+          });
+
+          expect(screen.getByTestId('tag-icon-7')).toBeInTheDocument();
+          expect(getTag(7)).toHaveAttribute('data-variant', 'error-fade');
+          expect(getRemoveButton(7)).toHaveAttribute('data-variant', 'error');
         });
 
         it('should remove a custom tag without opening the dropdown', async () => {
@@ -421,56 +486,50 @@ describe('TreeSelect', () => {
             selectedTagsOverflow,
             onChange,
             onOpenChange,
-            renderTag: (item, tagProps) => (
-              <TreeSelect.Tag {...tagProps} data-testid={`tag-${item.key}`}>
-                {item.textValue}
-              </TreeSelect.Tag>
-            ),
+            renderTag,
           });
 
-          await userEvent.click(
-            within(screen.getByTestId('tag-2')).getByRole('button', {
-              hidden: true,
-            })
-          );
+          await userEvent.click(getRemoveButton(2));
 
           expect(onChange).toHaveBeenCalledExactlyOnceWith([7]);
-          expect(screen.queryByTestId('tag-2')).not.toBeInTheDocument();
-          expect(screen.getByTestId('tag-7')).toHaveTextContent('README.md');
+          expect(queryTag(2)).not.toBeInTheDocument();
+          expect(getTag(7)).toHaveTextContent('README.md');
           expect(onOpenChange).not.toHaveBeenCalled();
           expect(queryPopover()).not.toBeInTheDocument();
         });
 
-        it.each(['isDisabled', 'isReadOnly'] as const)(
-          'should prevent custom tag removal when %s',
-          async (state) => {
+        it.each([
+          { isDisabled: true, isReadOnly: false },
+          { isDisabled: false, isReadOnly: true },
+        ] as const)(
+          'should prevent custom tag removal with %j',
+          async (states) => {
             const onChange = vi.fn();
 
             renderTreeSelect({
               selectionMode: 'multiple',
               defaultValue: [7],
               selectedTagsOverflow,
-              [state]: true,
+              ...states,
               onChange,
-              renderTag: (item, tagProps) => (
-                <TreeSelect.Tag {...tagProps} data-testid={`tag-${item.key}`}>
-                  {item.textValue}
-                </TreeSelect.Tag>
-              ),
+              renderTag,
             });
 
-            const tag = screen.getByTestId('tag-7');
-
-            const removeButton = within(tag).getByRole('button', {
-              hidden: true,
-            });
+            const tag = getTag(7);
+            const removeButton = getRemoveButton(7);
 
             expect(removeButton).toHaveAttribute('aria-disabled', 'true');
+
+            if (states.isDisabled) {
+              expect(tag).toHaveAttribute('data-disabled', 'true');
+            } else {
+              expect(tag).not.toHaveAttribute('data-disabled');
+            }
 
             await userEvent.click(removeButton);
 
             expect(onChange).not.toHaveBeenCalled();
-            expect(tag).toHaveTextContent('README.md');
+            expect(tag).toBeInTheDocument();
           }
         );
       }

--- a/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
@@ -368,6 +368,115 @@ describe('TreeSelect', () => {
     });
   });
 
+  describe('renderTag', () => {
+    it('should ignore renderTag in single selection mode', () => {
+      const renderTag = vi.fn(() => <div>Custom tag</div>);
+
+      renderTreeSelect({ defaultValue: 7, renderTag });
+
+      expect(getControl()).toHaveTextContent('README.md');
+      expect(renderTag).not.toHaveBeenCalled();
+    });
+
+    describe.each(['responsive', 'multiline'] as const)(
+      '%s overflow',
+      (selectedTagsOverflow) => {
+        it('should customize tags using selected items, including collapsed descendants', () => {
+          renderTreeSelect({
+            selectionMode: 'multiple',
+            defaultValue: [2, 7],
+            selectedTagsOverflow,
+            renderTag: (item, tagProps) => (
+              <TreeSelect.Tag
+                {...tagProps}
+                variant="warning-fade"
+                data-testid={`tag-${item.key}`}
+              >
+                File: {item.value?.title}
+              </TreeSelect.Tag>
+            ),
+          });
+
+          expect(screen.getByTestId('tag-2')).toHaveTextContent('File: Http');
+
+          expect(screen.getByTestId('tag-7')).toHaveTextContent(
+            'File: README.md'
+          );
+
+          expect(screen.getByTestId('tag-2')).toHaveAttribute(
+            'data-variant',
+            'warning-fade'
+          );
+
+          expect(screen.queryByTestId('tag-1')).not.toBeInTheDocument();
+        });
+
+        it('should remove a custom tag without opening the dropdown', async () => {
+          const onChange = vi.fn();
+          const onOpenChange = vi.fn();
+
+          renderTreeSelect({
+            selectionMode: 'multiple',
+            defaultValue: [2, 7],
+            selectedTagsOverflow,
+            onChange,
+            onOpenChange,
+            renderTag: (item, tagProps) => (
+              <TreeSelect.Tag {...tagProps} data-testid={`tag-${item.key}`}>
+                {item.textValue}
+              </TreeSelect.Tag>
+            ),
+          });
+
+          await userEvent.click(
+            within(screen.getByTestId('tag-2')).getByRole('button', {
+              hidden: true,
+            })
+          );
+
+          expect(onChange).toHaveBeenCalledExactlyOnceWith([7]);
+          expect(screen.queryByTestId('tag-2')).not.toBeInTheDocument();
+          expect(screen.getByTestId('tag-7')).toHaveTextContent('README.md');
+          expect(onOpenChange).not.toHaveBeenCalled();
+          expect(queryPopover()).not.toBeInTheDocument();
+        });
+
+        it.each(['isDisabled', 'isReadOnly'] as const)(
+          'should prevent custom tag removal when %s',
+          async (state) => {
+            const onChange = vi.fn();
+
+            renderTreeSelect({
+              selectionMode: 'multiple',
+              defaultValue: [7],
+              selectedTagsOverflow,
+              [state]: true,
+              onChange,
+              renderTag: (item, tagProps) => (
+                <TreeSelect.Tag {...tagProps} data-testid={`tag-${item.key}`}>
+                  {item.textValue}
+                </TreeSelect.Tag>
+              ),
+            });
+
+            const tag = screen.getByTestId('tag-7');
+
+            const removeButton = within(tag).getByRole('button', {
+              hidden: true,
+            });
+
+            expect(removeButton).toHaveAttribute('aria-disabled', 'true');
+
+            await userEvent.click(removeButton);
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(tag).toHaveTextContent('README.md');
+          }
+        );
+      }
+    );
+  });
+
   describe('disabled items', () => {
     it('should not select a disabled item', async () => {
       const onChange = vi.fn();

--- a/packages/components/src/components/TreeSelect/TreeSelect.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.tsx
@@ -54,6 +54,7 @@ import type { PopoverInnerProps, PopoverProps } from '../Popover';
 import { PopoverInner } from '../Popover/PopoverInner';
 import { SearchInput, type SearchInputProps } from '../SearchInput';
 import { SelectedTags } from '../SelectedTags';
+import { Tag } from '../Tag';
 import { Tree } from '../Tree';
 
 import intlMessages from './intl';
@@ -80,6 +81,7 @@ export function TreeSelectInner<
 >({ props, collection, controlRef }: TreeSelectInnerProps<T, M>) {
   const {
     selectedTagsOverflow = 'responsive',
+    renderTag,
     defaultInputValue = '',
     labelAlign,
     placeholder,
@@ -405,6 +407,7 @@ export function TreeSelectInner<
           isRequired,
         }}
         selectedTagsOverflow={selectedTagsOverflow}
+        renderTag={renderTag}
       />
     ) : (
       state.selectedItems[0]?.textValue
@@ -488,6 +491,7 @@ type CompoundedComponent = typeof TreeSelectComponent & {
   Item: typeof Tree.Item;
   ItemContent: typeof Tree.ItemContent;
   LoadMoreItem: typeof Tree.LoadMoreItem;
+  Tag: typeof Tag;
 };
 
 /** Select with hierarchical tree data. */
@@ -496,3 +500,4 @@ export const TreeSelect = TreeSelectComponent as CompoundedComponent;
 TreeSelect.Item = Tree.Item;
 TreeSelect.ItemContent = Tree.ItemContent;
 TreeSelect.LoadMoreItem = Tree.LoadMoreItem;
+TreeSelect.Tag = Tag;

--- a/packages/components/src/components/TreeSelect/types.ts
+++ b/packages/components/src/components/TreeSelect/types.ts
@@ -6,7 +6,7 @@ import type {
   Ref,
 } from 'react';
 
-import type { DataAttributeProps, RefObject } from '@koobiq/react-core';
+import type { DataAttributeProps, Node, RefObject } from '@koobiq/react-core';
 import type {
   SelectionMode,
   TreeProps as AriaTreeProps,
@@ -32,6 +32,7 @@ import type { IconButtonProps } from '../IconButton';
 import type { PopoverProps } from '../Popover';
 import type { SearchInputProps } from '../SearchInput';
 import { selectedTagsPropOverflow } from '../SelectedTags';
+import type { TagProps } from '../Tag';
 import type {
   TreeItemContentProps,
   TreeItemProps,
@@ -43,6 +44,7 @@ import type { TreeCollection } from './TreeInner';
 export type TreeSelectItemProps = TreeItemProps;
 export type TreeSelectItemContentProps = TreeItemContentProps;
 export type TreeSelectLoadMoreItemProps = TreeLoadMoreItemProps;
+export type TreeSelectTagProps = TagProps;
 
 export const treeSelectPropLabelPlacement = formFieldPropLabelPlacement;
 export type TreeSelectPropLabelPlacement = FormFieldPropLabelPlacement;
@@ -68,6 +70,8 @@ export type TreeSelectProps<
 > = {
   /** Defines how selected tags are displayed when they exceed the available space. */
   selectedTagsOverflow?: TreeSelectPropSelectedTagsOverflow;
+  /** Custom renderer for selected tags in multiple selection mode. */
+  renderTag?: (item: Node<T>, tagProps: TagProps) => ReactNode;
   /** Whether the field can be emptied. */
   isClearable?: boolean;
   /** Handler called when the clear button is clicked. */

--- a/packages/components/src/components/TreeSelect/types.ts
+++ b/packages/components/src/components/TreeSelect/types.ts
@@ -71,7 +71,7 @@ export type TreeSelectProps<
   /** Defines how selected tags are displayed when they exceed the available space. */
   selectedTagsOverflow?: TreeSelectPropSelectedTagsOverflow;
   /** Custom renderer for selected tags in multiple selection mode. */
-  renderTag?: (item: Node<T>, tagProps: TagProps) => ReactNode;
+  renderTag?: (item: Node<T>, tagProps: TreeSelectTagProps) => ReactNode;
   /** Whether the field can be emptied. */
   isClearable?: boolean;
   /** Handler called when the clear button is clicked. */

--- a/tools/public_api_guard/components/TreeSelect.api.md
+++ b/tools/public_api_guard/components/TreeSelect.api.md
@@ -93,6 +93,7 @@ export const treeSelectPropLabelPlacement: readonly ["top", "side"];
 // @public (undocumented)
 export type TreeSelectProps<T extends object, M extends SelectionMode_2 = 'single'> = {
     selectedTagsOverflow?: TreeSelectPropSelectedTagsOverflow;
+    renderTag?: (item: Node_2<T>, tagProps: TagProps) => ReactNode;
     isClearable?: boolean;
     onClear?: () => void;
     startAddon?: ReactNode;
@@ -146,19 +147,23 @@ export const treeSelectPropVariant: readonly ["filled", "transparent"];
 // @public (undocumented)
 export type TreeSelectRef = ComponentRef<'div'>;
 
+// @public (undocumented)
+export type TreeSelectTagProps = TagProps;
+
 // Warnings were encountered during analysis:
 //
-// packages/components/dist/components/TreeSelect/types.d.ts:81:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:82:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:83:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:84:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:85:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:86:9 - (ae-forgotten-export) The symbol "IconButtonProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:87:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:88:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:89:9 - (ae-forgotten-export) The symbol "DropdownFooterProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:91:9 - (ae-forgotten-export) The symbol "SearchInputProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TreeSelect/types.d.ts:98:5 - (ae-forgotten-export) The symbol "TreeCollection" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:29:5 - (ae-forgotten-export) The symbol "TagProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:85:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:86:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:87:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:88:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:89:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:90:9 - (ae-forgotten-export) The symbol "IconButtonProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:91:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:92:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:93:9 - (ae-forgotten-export) The symbol "DropdownFooterProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:95:9 - (ae-forgotten-export) The symbol "SearchInputProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TreeSelect/types.d.ts:102:5 - (ae-forgotten-export) The symbol "TreeCollection" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/components/TreeSelect.api.md
+++ b/tools/public_api_guard/components/TreeSelect.api.md
@@ -93,7 +93,7 @@ export const treeSelectPropLabelPlacement: readonly ["top", "side"];
 // @public (undocumented)
 export type TreeSelectProps<T extends object, M extends SelectionMode_2 = 'single'> = {
     selectedTagsOverflow?: TreeSelectPropSelectedTagsOverflow;
-    renderTag?: (item: Node_2<T>, tagProps: TagProps) => ReactNode;
+    renderTag?: (item: Node_2<T>, tagProps: TreeSelectTagProps) => ReactNode;
     isClearable?: boolean;
     onClear?: () => void;
     startAddon?: ReactNode;
@@ -147,12 +147,13 @@ export const treeSelectPropVariant: readonly ["filled", "transparent"];
 // @public (undocumented)
 export type TreeSelectRef = ComponentRef<'div'>;
 
+// Warning: (ae-forgotten-export) The symbol "TagProps" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type TreeSelectTagProps = TagProps;
 
 // Warnings were encountered during analysis:
 //
-// packages/components/dist/components/TreeSelect/types.d.ts:29:5 - (ae-forgotten-export) The symbol "TagProps" needs to be exported by the entry point index.d.ts
 // packages/components/dist/components/TreeSelect/types.d.ts:85:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
 // packages/components/dist/components/TreeSelect/types.d.ts:86:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
 // packages/components/dist/components/TreeSelect/types.d.ts:87:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing selected tags in `TreeSelect` with the `renderTag` option.
  - Exposed `TreeSelect.Tag` for creating styled custom tags, including icons and warning variants.
  - Custom tags work across responsive and multiline layouts and respect disabled or read-only states.

- **Documentation**
  - Added usage guidance and an example demonstrating custom tag rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->