### PR TITLE
fix(Popover, Modal, SidePanel): unify the overlay z-index layer (DS-5504)

### DIFF
--- a/packages/components/src/components/FileUpload/components/FileUploadDropTargetOverlay/FileUploadDropTargetOverlay.module.css
+++ b/packages/components/src/components/FileUpload/components/FileUploadDropTargetOverlay/FileUploadDropTargetOverlay.module.css
@@ -1,5 +1,5 @@
 .base {
-  z-index: var(--kbq-layer-modal);
+  z-index: var(--kbq-layer-overlay);
   display: flex;
   position: fixed;
   overflow: hidden;

--- a/packages/components/src/components/Modal/Modal.mdx
+++ b/packages/components/src/components/Modal/Modal.mdx
@@ -105,3 +105,12 @@ You can adjust the interaction with the modal window using the following propert
 - `disableExitOnEscapeKeyDown` — if `true`, the component won't close when the ESC key is pressed.
 
 <Story of={Stories.Settings} />
+
+## Overlay stacking
+
+All overlays share one layer, `--kbq-layer-overlay` (`1000`), so the last one
+opened is on top. Toasts are the exception: `--kbq-layer-toast` is above them all.
+
+Keep your app's own `z-index` values below `1000`.
+
+<Story of={Stories.Stacking} />

--- a/packages/components/src/components/Modal/Modal.mdx
+++ b/packages/components/src/components/Modal/Modal.mdx
@@ -108,9 +108,10 @@ You can adjust the interaction with the modal window using the following propert
 
 ## Overlay stacking
 
-All overlays share one layer, `--kbq-layer-overlay` (`1000`), so the last one
-opened is on top. Toasts are the exception: `--kbq-layer-toast` is above them all.
+All overlays share one layer, `--kbq-layer-overlay`, so the last one opened is
+on top. Toasts are the exception: `--kbq-layer-toast` is above them all.
 
-Keep your app's own `z-index` values below `1000`.
+Keep your app's own `z-index` values below `--kbq-layer-topbar`, the lowest
+layer the library occupies.
 
 <Story of={Stories.Stacking} />

--- a/packages/components/src/components/Modal/Modal.module.css
+++ b/packages/components/src/components/Modal/Modal.module.css
@@ -5,7 +5,7 @@
   display: flex;
   position: fixed;
   pointer-events: none;
-  z-index: var(--kbq-layer-modal);
+  z-index: var(--kbq-layer-overlay);
 }
 
 /* states */

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { useBoolean } from '@koobiq/react-core';
+import { useBoolean, useTimer } from '@koobiq/react-core';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
@@ -24,7 +24,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['status:updated', 'date:2026-09-09'],
 } satisfies Meta<typeof Modal>;
 
 export default meta;
@@ -218,6 +217,12 @@ export const Stacking: Story = {
   render: function Render() {
     const [isOpen, { on, set }] = useBoolean(false);
 
+    const { count, isTimerRunning, startTimer } = useTimer({
+      startTime: 1500,
+      interval: 500,
+      onTimerEnd: on,
+    });
+
     const items = [
       <Select.Item id="bruteforce" key="bruteforce">
         Bruteforce
@@ -242,8 +247,10 @@ export const Stacking: Story = {
         >
           {items}
         </Select>
-        <Button onPress={() => setTimeout(on, 1500)}>
-          Open the modal in 1.5s
+        <Button onPress={startTimer}>
+          {isTimerRunning
+            ? `Opening the modal in ${count / 1000}s`
+            : 'Open the modal in 1.5s'}
         </Button>
         <Modal isOpen={isOpen} size="small" onOpenChange={set}>
           <Modal.Header>Overlay stacking</Modal.Header>

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -5,8 +5,10 @@ import { Button } from '../Button';
 import { FlexBox } from '../FlexBox';
 import { Form } from '../Form';
 import { Input } from '../Input';
+import { SelectNext as Select } from '../SelectNext';
 import { Textarea } from '../Textarea';
 import { Toggle } from '../Toggle';
+import { Typography } from '../Typography';
 
 import { Modal } from './index';
 import { modalPropSize } from './index.js';
@@ -22,6 +24,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  tags: ['status:updated', 'date:2026-09-09'],
 } satisfies Meta<typeof Modal>;
 
 export default meta;
@@ -207,6 +210,60 @@ export const Settings: Story = {
           </>
         )}
       </Modal>
+    );
+  },
+};
+
+export const Stacking: Story = {
+  render: function Render() {
+    const [isOpen, { on, set }] = useBoolean(false);
+
+    const items = [
+      <Select.Item id="bruteforce" key="bruteforce">
+        Bruteforce
+      </Select.Item>,
+      <Select.Item id="ddos" key="ddos">
+        DDoS
+      </Select.Item>,
+      <Select.Item id="identity-theft" key="identity-theft">
+        Identity Theft
+      </Select.Item>,
+      <Select.Item id="network-attack" key="network-attack">
+        Network Attack
+      </Select.Item>,
+    ];
+
+    return (
+      <FlexBox gap="l" direction="column" alignItems="flex-start">
+        <Select
+          label="Attack type"
+          style={{ inlineSize: 200 }}
+          placeholder="Select an option"
+        >
+          {items}
+        </Select>
+        <Button onPress={() => setTimeout(on, 1500)}>
+          Open the modal in 1.5s
+        </Button>
+        <Modal isOpen={isOpen} size="small" onOpenChange={set}>
+          <Modal.Header>Overlay stacking</Modal.Header>
+          <Modal.Body>
+            <FlexBox gap="l" direction="column" alignItems="flex-start">
+              <Typography variant="text-normal">
+                The dropdown above opened before this modal, so the modal covers
+                it. The one below opens last and stays on top.
+              </Typography>
+              <Select
+                label="Attack type"
+                style={{ inlineSize: 200 }}
+                placeholder="Select an option"
+              >
+                {items}
+              </Select>
+            </FlexBox>
+          </Modal.Body>
+        </Modal>
+      </FlexBox>
     );
   },
 };

--- a/packages/components/src/components/Modal/Modal.test.tsx
+++ b/packages/components/src/components/Modal/Modal.test.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { Button } from '../Button';
+import { Popover } from '../Popover';
 
 import { Modal } from './Modal';
 import { type ModalProps, modalPropSize } from './types';
@@ -307,6 +308,52 @@ describe('Modal', () => {
       expect(onOpenChange).toHaveBeenCalledTimes(1);
 
       expect(onOpenChange.mock.results[0]?.value).toStrictEqual(false);
+    });
+  });
+
+  // Every overlay shares one z-index layer, so the DOM order of the portals
+  // decides which one is on top: whatever opens last wins.
+  describe('overlay stacking', () => {
+    it('should be portaled after a popover that was already open', () => {
+      const { rerender } = render(
+        <>
+          <Popover data-testid="popover" isOpen />
+          <Modal {...baseProps} isOpen={false} />
+        </>
+      );
+
+      rerender(
+        <>
+          <Popover data-testid="popover" isOpen />
+          <Modal {...baseProps} isOpen />
+        </>
+      );
+
+      const position = screen
+        .getByTestId('popover')
+        .compareDocumentPosition(getModal());
+
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('should be portaled before a popover opened from inside it', () => {
+      const { rerender } = render(
+        <Modal {...baseProps} isOpen>
+          <Popover data-testid="popover" isOpen={false} />
+        </Modal>
+      );
+
+      rerender(
+        <Modal {...baseProps} isOpen>
+          <Popover data-testid="popover" isOpen />
+        </Modal>
+      );
+
+      const position = getModal().compareDocumentPosition(
+        screen.getByTestId('popover')
+      );
+
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
   });
 });

--- a/packages/components/src/components/Popover/Popover.module.css
+++ b/packages/components/src/components/Popover/Popover.module.css
@@ -3,6 +3,7 @@
   --popover-border-radius: var(--kbq-size-m);
 
   display: flex;
+  z-index: var(--kbq-layer-overlay);
   border-radius: var(--kbq-popover-border-radius, var(--popover-border-radius));
   box-shadow: var(--kbq-shadow-overlay);
   background-color: var(--kbq-background-bg);

--- a/packages/components/src/components/Popover/Popover.test.tsx
+++ b/packages/components/src/components/Popover/Popover.test.tsx
@@ -50,6 +50,18 @@ describe('Popover', () => {
     expect(root).toHaveStyle({ padding: '20px' });
   });
 
+  it('should not inline the react-aria z-index, so the CSS layer applies', () => {
+    render(<Popover {...baseProps} isOpen />);
+
+    expect(getRoot().style.zIndex).toBe('');
+  });
+
+  it('should let a custom z-index override the layer', () => {
+    render(<Popover {...baseProps} style={{ zIndex: 5 }} isOpen />);
+
+    expect(getRoot()).toHaveStyle({ zIndex: '5' });
+  });
+
   describe('check the size prop', () => {
     it.each(popoverPropSize)('should apply the size as a "%s"', (size) => {
       render(<Popover {...baseProps} size={size} isOpen />);

--- a/packages/components/src/components/Popover/PopoverInner.tsx
+++ b/packages/components/src/components/Popover/PopoverInner.tsx
@@ -151,6 +151,14 @@ export const PopoverInner: FC<PopoverInnerProps> = (props) => {
       ? children({ close: state.close })
       : children;
 
+  const popoverStyle = {
+    ...popoverProps.style,
+    // React Aria hardcodes `z-index: 100000` here. Strip it so the layer comes
+    // from CSS and every overlay shares one stacking plane, where the DOM order
+    // of the portals decides. A `style` prop from above still wins.
+    zIndex: props.style?.zIndex,
+  };
+
   const renderPopover = (transition: string) => (
     <div
       ref={domRef}
@@ -163,7 +171,7 @@ export const PopoverInner: FC<PopoverInnerProps> = (props) => {
       style={
         {
           ...props.style,
-          ...popoverProps.style,
+          ...popoverStyle,
           '--popover-inline-size': normalizeInlineSize(size),
         } as CSSProperties
       }

--- a/packages/components/src/components/Popover/PopoverInner.tsx
+++ b/packages/components/src/components/Popover/PopoverInner.tsx
@@ -151,14 +151,6 @@ export const PopoverInner: FC<PopoverInnerProps> = (props) => {
       ? children({ close: state.close })
       : children;
 
-  const popoverStyle = {
-    ...popoverProps.style,
-    // React Aria hardcodes `z-index: 100000` here. Strip it so the layer comes
-    // from CSS and every overlay shares one stacking plane, where the DOM order
-    // of the portals decides. A `style` prop from above still wins.
-    zIndex: props.style?.zIndex,
-  };
-
   const renderPopover = (transition: string) => (
     <div
       ref={domRef}
@@ -171,7 +163,11 @@ export const PopoverInner: FC<PopoverInnerProps> = (props) => {
       style={
         {
           ...props.style,
-          ...popoverStyle,
+          ...popoverProps.style,
+          // React Aria hardcodes `z-index: 100000` here. Strip it so the layer
+          // comes from CSS and every overlay shares one stacking plane, where
+          // the DOM order of the portals decides. A `style` prop still wins.
+          zIndex: props.style?.zIndex,
           '--popover-inline-size': normalizeInlineSize(size),
         } as CSSProperties
       }

--- a/packages/components/src/components/SidePanel/SidePanel.module.css
+++ b/packages/components/src/components/SidePanel/SidePanel.module.css
@@ -3,7 +3,7 @@
   display: flex;
   position: fixed;
   pointer-events: none;
-  z-index: var(--kbq-layer-modal);
+  z-index: var(--kbq-layer-overlay);
 }
 
 /* states */

--- a/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -10,7 +10,7 @@
   min-inline-size: 48px;
   min-block-size: 36px;
   color: var(--tooltip-color);
-  z-index: var(--kbq-layer-modal);
+  z-index: var(--kbq-layer-overlay);
   border-radius: var(--kbq-size-s);
   background-color: var(--tooltip-bg-color);
   transition: opacity var(--kbq-transition-default);

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -34,12 +34,6 @@ describe('Tooltip', () => {
     expect(ref.current).toBe(getRoot());
   });
 
-  it('should not inline the react-aria z-index, so the CSS layer applies', () => {
-    render(<Tooltip {...baseProps} isOpen />);
-
-    expect(getRoot().style.zIndex).toBe('');
-  });
-
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
 

--- a/packages/components/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.test.tsx
@@ -34,6 +34,12 @@ describe('Tooltip', () => {
     expect(ref.current).toBe(getRoot());
   });
 
+  it('should not inline the react-aria z-index, so the CSS layer applies', () => {
+    render(<Tooltip {...baseProps} isOpen />);
+
+    expect(getRoot().style.zIndex).toBe('');
+  });
+
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
 

--- a/packages/components/src/global.css
+++ b/packages/components/src/global.css
@@ -3,11 +3,9 @@
   --kbq-layer-default: 0;
   --kbq-layer-absolute: 1;
   --kbq-layer-topbar: 950;
-  --kbq-layer-overlay: 1000;
+  --kbq-layer-modal: 1000; /* @deprecated Use `--kbq-layer-overlay`. */
+  --kbq-layer-overlay: var(--kbq-layer-modal);
   --kbq-layer-toast: 1100;
-
-  /** @deprecated Use `--kbq-layer-overlay` instead. */
-  --kbq-layer-modal: var(--kbq-layer-overlay);
 
   /* transition */
   --kbq-transition-default: 120ms ease-in-out;

--- a/packages/components/src/global.css
+++ b/packages/components/src/global.css
@@ -3,8 +3,11 @@
   --kbq-layer-default: 0;
   --kbq-layer-absolute: 1;
   --kbq-layer-topbar: 950;
-  --kbq-layer-modal: 1000;
+  --kbq-layer-overlay: 1000;
   --kbq-layer-toast: 1100;
+
+  /** @deprecated Use `--kbq-layer-overlay` instead. */
+  --kbq-layer-modal: var(--kbq-layer-overlay);
 
   /* transition */
   --kbq-transition-default: 120ms ease-in-out;

--- a/packages/components/src/global.test.ts
+++ b/packages/components/src/global.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+const read = (path: string) => readFileSync(join(root, path), 'utf8');
+
+const overlays = [
+  'components/Modal/Modal.module.css',
+  'components/Popover/Popover.module.css',
+  'components/SidePanel/SidePanel.module.css',
+  'components/Tooltip/Tooltip.module.css',
+  'components/FileUpload/components/FileUploadDropTargetOverlay/FileUploadDropTargetOverlay.module.css',
+];
+
+// Overlays only share a stacking plane while they all point at the same layer,
+// and jsdom resolves neither custom properties nor CSS Modules values — so the
+// wiring is guarded by reading the stylesheets.
+describe('overlay layer', () => {
+  it('should keep every overlay on a single layer', () => {
+    const layers = overlays.map(
+      (path) => read(path).match(/z-index: var\((--kbq-layer-[a-z]+)\)/)?.[1]
+    );
+
+    expect(new Set(layers)).toStrictEqual(new Set(['--kbq-layer-overlay']));
+  });
+
+  it('should keep the deprecated alias resolving to that layer', () => {
+    expect(read('global.css')).toMatch(
+      /--kbq-layer-overlay:\s*var\(--kbq-layer-modal\);/
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized modals, popovers, tooltips, file upload overlays, and side panels on a shared overlay stacking layer.
  * Ensured popovers honor the shared layer while still allowing explicit custom stacking values.

* **Documentation**
  * Added guidance and an interactive example explaining overlay stacking order, including toast behavior and application stacking limits.

* **Tests**
  * Added coverage validating overlay ordering and stacking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->