### PR TITLE
fix(FormField): unify addon and action states in readonly and disabled (DS-5292)

### DIFF
--- a/packages/components/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.test.tsx
@@ -413,7 +413,7 @@ describe('Autocomplete', () => {
       expect(onClear).toHaveBeenCalledTimes(1);
     });
 
-    it('should NOT render clear button when the component is disabled', async () => {
+    it('should render a disabled clear button when the component is disabled', () => {
       const onClear = vi.fn();
 
       render(
@@ -432,10 +432,11 @@ describe('Autocomplete', () => {
 
       const clearButton = getClearButton();
 
-      expect(clearButton).toHaveAttribute('aria-hidden', 'true');
+      expect(clearButton).not.toHaveAttribute('aria-hidden', 'true');
+      expect(clearButton).toBeDisabled();
     });
 
-    it('should NOT render clear button when the component is read only', async () => {
+    it('should render a disabled clear button when the component is read only', async () => {
       const onClear = vi.fn();
 
       render(
@@ -454,7 +455,12 @@ describe('Autocomplete', () => {
 
       const clearButton = getClearButton();
 
-      expect(clearButton).toHaveAttribute('aria-hidden', 'true');
+      expect(clearButton).not.toHaveAttribute('aria-hidden', 'true');
+      expect(clearButton).toBeDisabled();
+
+      if (clearButton) await userEvent.click(clearButton);
+
+      expect(onClear).not.toHaveBeenCalled();
     });
 
     it('should show clear button when any value is entered with allowsCustomValue', async () => {

--- a/packages/components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.tsx
@@ -136,15 +136,16 @@ export function AutocompleteRender<T extends object = object>(
     state
   );
 
-  const clearButtonIsHidden =
-    isReadOnly ||
-    isDisabled ||
-    (allowsCustomValue ? !state.inputValue : !state.selectedItem);
+  const clearButtonIsHidden = allowsCustomValue
+    ? !state.inputValue
+    : !state.selectedItem;
 
   const handleClear = useCallback(() => {
+    if (isReadOnly) return;
+
     state.selectionManager.setSelectedKeys(new Set());
     onClear?.();
-  }, [onClear, state]);
+  }, [isReadOnly, onClear, state]);
 
   const { isInvalid } = validation;
 
@@ -262,6 +263,7 @@ export function AutocompleteRender<T extends object = object>(
       variant,
       isInvalid,
       isDisabled,
+      isReadOnly,
       ref: containerRef,
     },
     slotProps?.group

--- a/packages/components/src/components/DateInput/DateInput.tsx
+++ b/packages/components/src/components/DateInput/DateInput.tsx
@@ -133,6 +133,7 @@ export function DateInputRender<T extends DateValue>(
       endAddon,
       isInvalid,
       isDisabled,
+      isReadOnly,
       startAddon,
       variant,
       onMouseDown: (e) => {

--- a/packages/components/src/components/Form/Form.stories.tsx
+++ b/packages/components/src/components/Form/Form.stories.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useRef, useState } from 'react';
 
+import { Time, parseDate } from '@internationalized/date';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Alert } from '../Alert';
@@ -16,11 +17,12 @@ import { InputNumber } from '../InputNumber';
 import { spacing } from '../layout';
 import { Radio, RadioGroup } from '../RadioGroup';
 import { SearchInput } from '../SearchInput';
-import { Select } from '../Select';
+import { SelectNext } from '../SelectNext';
 import { TagInput } from '../TagInput';
 import { Textarea } from '../Textarea';
 import { TimePicker } from '../TimePicker';
 import { TimeRange } from '../TimeRange';
+import { Toggle } from '../Toggle';
 import { TreeSelect } from '../TreeSelect';
 import { Typography } from '../Typography';
 
@@ -430,6 +432,9 @@ export const FormFields: Story = {
   },
   name: 'All form fields',
   render: function Render() {
+    const [isDisabled, setDisabled] = useState(false);
+    const [isReadOnly, setReadOnly] = useState(false);
+
     const tags = useListData<{ id: string; name: string }>({
       initialItems: [{ id: 'react', name: 'React' }],
     });
@@ -450,112 +455,164 @@ export const FormFields: Story = {
     };
 
     return (
-      <Form
-        labelPlacement={{ xs: 'top', m: 'side' }}
-        labelInlineSize="2/5"
-        style={{ maxWidth: 400 }}
-      >
-        <Select label="Select" placeholder="Select an option">
-          <Select.Item key="1">Option 1</Select.Item>
-          <Select.Item key="2">Option 2</Select.Item>
-          <Select.Item key="3">Option 3</Select.Item>
-        </Select>
-        <Input label="Input" placeholder="Type a word..." />
-        <TagInput<{ id: string; name: string }>
-          label="Tag input"
-          placeholder="Type and press Enter"
-          items={tags.items}
-          onAdd={addTags}
-          onRemove={(keys) => tags.remove(...keys)}
+      <>
+        <FlexBox
+          gap="l"
+          style={{ maxWidth: 400, marginBlockEnd: 'var(--kbq-size-l)' }}
         >
-          {(item) => <TagInput.Tag key={item.id}>{item.name}</TagInput.Tag>}
-        </TagInput>
-        <Textarea label="Textarea" placeholder="Type a word..." />
-        <InputNumber label="InputNumber" placeholder="Type a number..." />
-        <SearchInput label="SearchInput" placeholder="Type a word..." />
-        <TimePicker label="TimePicker" />
-        <DatePicker label="DatePicker" />
-        <RadioGroup label="RadioGroup" defaultValue="windows">
-          <Radio value="windows">Windows</Radio>
-          <Radio value="macos">macOS</Radio>
-          <Radio value="linux">Linux</Radio>
-          <Radio value="other">Other</Radio>
-        </RadioGroup>
-        <Autocomplete
-          label="Autocomplete"
-          placeholder="Select a protocol"
-          disableShowChevron
+          <Toggle isSelected={isDisabled} onChange={setDisabled}>
+            isDisabled
+          </Toggle>
+          <Toggle isSelected={isReadOnly} onChange={setReadOnly}>
+            isReadOnly
+          </Toggle>
+        </FlexBox>
+        <Form
+          labelPlacement={{ xs: 'top', m: 'side' }}
+          labelInlineSize="2/5"
+          style={{ maxWidth: 400 }}
+          isDisabled={isDisabled}
+          isReadOnly={isReadOnly}
         >
-          <Autocomplete.Item key="tls">TLS</Autocomplete.Item>
-          <Autocomplete.Item key="ssh">SSH</Autocomplete.Item>
-          <Autocomplete.Item key="pgp">PGP</Autocomplete.Item>
-          <Autocomplete.Item key="ipsec">IPSec</Autocomplete.Item>
-          <Autocomplete.Item key="kerberos">Kerberos</Autocomplete.Item>
-        </Autocomplete>
-        <TreeSelect
-          label="TreeSelect"
-          placeholder="Pick value"
-          selectionMode="multiple"
-          isClearable
-        >
-          <TreeSelect.Item id={1} textValue="app">
-            <TreeSelect.ItemContent>app</TreeSelect.ItemContent>
-            <TreeSelect.Item id={2} textValue="Http">
-              <TreeSelect.ItemContent>Http</TreeSelect.ItemContent>
-              <TreeSelect.Item id={3} textValue="index.html">
-                <TreeSelect.ItemContent>index.html</TreeSelect.ItemContent>
+          <SelectNext
+            label="Select"
+            placeholder="Select an option"
+            defaultValue="1"
+            isClearable
+          >
+            <SelectNext.Item id="1">Option 1</SelectNext.Item>
+            <SelectNext.Item id="2">Option 2</SelectNext.Item>
+            <SelectNext.Item id="3">Option 3</SelectNext.Item>
+          </SelectNext>
+          <Input
+            label="Input"
+            placeholder="Type a word..."
+            defaultValue="Some text"
+            isClearable
+          />
+          <TagInput<{ id: string; name: string }>
+            label="Tag input"
+            placeholder="Type and press Enter"
+            items={tags.items}
+            onAdd={addTags}
+            onRemove={(keys) => tags.remove(...keys)}
+          >
+            {(item) => <TagInput.Tag key={item.id}>{item.name}</TagInput.Tag>}
+          </TagInput>
+          <Textarea
+            label="Textarea"
+            placeholder="Type a word..."
+            defaultValue="Some longer text"
+          />
+          <InputNumber
+            label="InputNumber"
+            placeholder="Type a number..."
+            defaultValue={42}
+          />
+          <SearchInput
+            label="SearchInput"
+            placeholder="Type a word..."
+            defaultValue="best js tricks"
+          />
+          <TimePicker label="TimePicker" defaultValue={new Time(11, 45)} />
+          <DatePicker
+            label="DatePicker"
+            defaultValue={parseDate('2025-02-03')}
+          />
+          <RadioGroup label="RadioGroup" defaultValue="windows">
+            <Radio value="windows">Windows</Radio>
+            <Radio value="macos">macOS</Radio>
+            <Radio value="linux">Linux</Radio>
+            <Radio value="other">Other</Radio>
+          </RadioGroup>
+          <Autocomplete
+            label="Autocomplete"
+            placeholder="Select a protocol"
+            defaultSelectedKey="tls"
+            isClearable
+          >
+            <Autocomplete.Item key="tls">TLS</Autocomplete.Item>
+            <Autocomplete.Item key="ssh">SSH</Autocomplete.Item>
+            <Autocomplete.Item key="pgp">PGP</Autocomplete.Item>
+            <Autocomplete.Item key="ipsec">IPSec</Autocomplete.Item>
+            <Autocomplete.Item key="kerberos">Kerberos</Autocomplete.Item>
+          </Autocomplete>
+          <TreeSelect
+            label="TreeSelect"
+            placeholder="Pick value"
+            selectionMode="multiple"
+            defaultValue={[1, 7]}
+            isClearable
+          >
+            <TreeSelect.Item id={1} textValue="app">
+              <TreeSelect.ItemContent>app</TreeSelect.ItemContent>
+              <TreeSelect.Item id={2} textValue="Http">
+                <TreeSelect.ItemContent>Http</TreeSelect.ItemContent>
+                <TreeSelect.Item id={3} textValue="index.html">
+                  <TreeSelect.ItemContent>index.html</TreeSelect.ItemContent>
+                </TreeSelect.Item>
+              </TreeSelect.Item>
+              <TreeSelect.Item id={4} textValue="Providers">
+                <TreeSelect.ItemContent>Providers</TreeSelect.ItemContent>
+                <TreeSelect.Item id={5} textValue="EventServiceProvider.js">
+                  <TreeSelect.ItemContent>
+                    EventServiceProvider.js
+                  </TreeSelect.ItemContent>
+                </TreeSelect.Item>
               </TreeSelect.Item>
             </TreeSelect.Item>
-            <TreeSelect.Item id={4} textValue="Providers">
-              <TreeSelect.ItemContent>Providers</TreeSelect.ItemContent>
-              <TreeSelect.Item id={5} textValue="EventServiceProvider.js">
-                <TreeSelect.ItemContent>
-                  EventServiceProvider.js
-                </TreeSelect.ItemContent>
+            <TreeSelect.Item id={6} textValue="config">
+              <TreeSelect.ItemContent>config</TreeSelect.ItemContent>
+              <TreeSelect.Item id={7} textValue="app.js">
+                <TreeSelect.ItemContent>app.js</TreeSelect.ItemContent>
+              </TreeSelect.Item>
+              <TreeSelect.Item id={8} textValue="database.js">
+                <TreeSelect.ItemContent>database.js</TreeSelect.ItemContent>
               </TreeSelect.Item>
             </TreeSelect.Item>
-          </TreeSelect.Item>
-          <TreeSelect.Item id={6} textValue="config">
-            <TreeSelect.ItemContent>config</TreeSelect.ItemContent>
-            <TreeSelect.Item id={7} textValue="app.js">
-              <TreeSelect.ItemContent>app.js</TreeSelect.ItemContent>
+            <TreeSelect.Item id={9} textValue="public">
+              <TreeSelect.ItemContent>public</TreeSelect.ItemContent>
+              <TreeSelect.Item id={10} textValue="logo.svg">
+                <TreeSelect.ItemContent>logo.svg</TreeSelect.ItemContent>
+              </TreeSelect.Item>
             </TreeSelect.Item>
-            <TreeSelect.Item id={8} textValue="database.js">
-              <TreeSelect.ItemContent>database.js</TreeSelect.ItemContent>
+            <TreeSelect.Item id={11} textValue=".env">
+              <TreeSelect.ItemContent>.env</TreeSelect.ItemContent>
             </TreeSelect.Item>
-          </TreeSelect.Item>
-          <TreeSelect.Item id={9} textValue="public">
-            <TreeSelect.ItemContent>public</TreeSelect.ItemContent>
-            <TreeSelect.Item id={10} textValue="logo.svg">
-              <TreeSelect.ItemContent>logo.svg</TreeSelect.ItemContent>
+            <TreeSelect.Item id={12} textValue=".gitignore">
+              <TreeSelect.ItemContent>.gitignore</TreeSelect.ItemContent>
             </TreeSelect.Item>
-          </TreeSelect.Item>
-          <TreeSelect.Item id={11} textValue=".env">
-            <TreeSelect.ItemContent>.env</TreeSelect.ItemContent>
-          </TreeSelect.Item>
-          <TreeSelect.Item id={12} textValue=".gitignore">
-            <TreeSelect.ItemContent>.gitignore</TreeSelect.ItemContent>
-          </TreeSelect.Item>
-          <TreeSelect.Item id={13} textValue="README.md">
-            <TreeSelect.ItemContent>README.md</TreeSelect.ItemContent>
-          </TreeSelect.Item>
-        </TreeSelect>
-        <CheckboxGroup label="CheckboxGroup" defaultValue={['one']}>
-          <Checkbox value="one">One</Checkbox>
-          <Checkbox value="two">Two</Checkbox>
-          <Checkbox value="three">Three</Checkbox>
-        </CheckboxGroup>
-        <FormField>
-          <FormField.Label as="span">Inputs</FormField.Label>
-          <FlexBox gap="m" style={{ inlineSize: '100%' }}>
-            <Input aria-label="first" placeholder="Input 1" />
-            <Input aria-label="second" placeholder="Input 2" />
-          </FlexBox>
-        </FormField>
-        <TimeRange defaultValue={null}>
-          <TimeRange.Field label="TimeRange" placeholder="Select a period" />
-        </TimeRange>
-      </Form>
+            <TreeSelect.Item id={13} textValue="README.md">
+              <TreeSelect.ItemContent>README.md</TreeSelect.ItemContent>
+            </TreeSelect.Item>
+          </TreeSelect>
+          <CheckboxGroup label="CheckboxGroup" defaultValue={['one']}>
+            <Checkbox value="one">One</Checkbox>
+            <Checkbox value="two">Two</Checkbox>
+            <Checkbox value="three">Three</Checkbox>
+          </CheckboxGroup>
+          <FormField>
+            <FormField.Label as="span">Inputs</FormField.Label>
+            <FlexBox gap="m" style={{ inlineSize: '100%' }}>
+              <Input
+                aria-label="first"
+                placeholder="Input 1"
+                defaultValue="One"
+                isClearable
+              />
+              <Input
+                aria-label="second"
+                placeholder="Input 2"
+                defaultValue="Two"
+                isClearable
+              />
+            </FlexBox>
+          </FormField>
+          <TimeRange defaultValue={null}>
+            <TimeRange.Field label="TimeRange" placeholder="Select a period" />
+          </TimeRange>
+        </Form>
+      </>
     );
   },
 };

--- a/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.module.css
+++ b/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.module.css
@@ -13,6 +13,10 @@
   --form-field-addon-color: var(--kbq-icon-error);
 }
 
+.readonly {
+  --form-field-addon-color: var(--kbq-states-icon-disabled);
+}
+
 .disabled {
   --form-field-addon-color: var(--kbq-states-icon-disabled);
 }

--- a/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.module.css
+++ b/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.module.css
@@ -13,10 +13,7 @@
   --form-field-addon-color: var(--kbq-icon-error);
 }
 
-.readonly {
-  --form-field-addon-color: var(--kbq-states-icon-disabled);
-}
-
+.readonly,
 .disabled {
   --form-field-addon-color: var(--kbq-states-icon-disabled);
 }

--- a/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.tsx
+++ b/packages/components/src/components/FormField/FormFieldAddon/FormFieldAddon.tsx
@@ -27,7 +27,7 @@ export const FormFieldAddon = forwardRef<
   FormFieldAddonRef,
   FormFieldAddonProps
 >(({ placement = 'start', className, children, ...other }, ref) => {
-  const { isInvalid, isDisabled } = useFormFieldControlGroup();
+  const { isInvalid, isDisabled, isReadOnly } = useFormFieldControlGroup();
 
   return isNotNil(children) ? (
     <div
@@ -35,11 +35,13 @@ export const FormFieldAddon = forwardRef<
         s.base,
         s[placement],
         isInvalid && s.invalid,
+        isReadOnly && s.readonly,
         isDisabled && s.disabled,
         className
       )}
       data-placement={placement}
       data-invalid={isInvalid || undefined}
+      data-readonly={isReadOnly || undefined}
       data-disabled={isDisabled || undefined}
       data-testid={`field-addon-${placement}`}
       {...other}

--- a/packages/components/src/components/FormField/FormFieldClearButton/FormFieldClearButton.tsx
+++ b/packages/components/src/components/FormField/FormFieldClearButton/FormFieldClearButton.tsx
@@ -17,8 +17,13 @@ export type FormFieldClearButtonProps = {
 export const FormFieldClearButton = forwardRef<
   ComponentRef<'button'>,
   FormFieldClearButtonProps
->(({ isHidden, isClearable, className, ...other }, ref) => {
-  const { isInvalid } = useFormFieldControlGroup();
+>(({ isHidden, isClearable, isDisabled, className, ...other }, ref) => {
+  const {
+    isInvalid,
+    isDisabled: isGroupDisabled,
+    isReadOnly,
+  } = useFormFieldControlGroup();
+
   const t = useLocalizedStringFormatter(intlMessages);
 
   if (!isClearable) return null;
@@ -30,6 +35,7 @@ export const FormFieldClearButton = forwardRef<
       aria-hidden={isHidden}
       tabIndex={isHidden ? -1 : undefined}
       className={clsx(s.base, className)}
+      isDisabled={isDisabled || isGroupDisabled || isReadOnly}
       variant={isInvalid ? 'error' : 'fade-contrast'}
       aria-label={t.format('clear')}
       ref={ref}

--- a/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.test.tsx
+++ b/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
+import addonStyles from '../FormFieldAddon/FormFieldAddon.module.css';
+
 import s from './FormFieldControlGroup.module.css';
 import { FormFieldControlGroup } from './index';
 
@@ -44,10 +46,10 @@ describe('FormFieldControlGroup', () => {
     expect(getRoot()).toHaveAttribute('data-readonly', 'true');
 
     ['start', 'end'].forEach((placement) => {
-      expect(screen.getByTestId(`field-addon-${placement}`)).toHaveAttribute(
-        'data-readonly',
-        'true'
-      );
+      const addon = screen.getByTestId(`field-addon-${placement}`);
+
+      expect(addon).toHaveAttribute('data-readonly', 'true');
+      expect(addon).toHaveClass(addonStyles.readonly);
     });
   });
 

--- a/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.test.tsx
+++ b/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.test.tsx
@@ -28,4 +28,40 @@ describe('FormFieldControlGroup', () => {
       expect(getRoot()).toHaveClass(s.focused);
     });
   });
+
+  it('should mark the group and its addons as read-only', () => {
+    render(
+      <FormFieldControlGroup
+        data-testid="root"
+        isReadOnly
+        startAddon={<span>start</span>}
+        endAddon={<span>end</span>}
+      >
+        <input data-testid="input" />
+      </FormFieldControlGroup>
+    );
+
+    expect(getRoot()).toHaveAttribute('data-readonly', 'true');
+
+    ['start', 'end'].forEach((placement) => {
+      expect(screen.getByTestId(`field-addon-${placement}`)).toHaveAttribute(
+        'data-readonly',
+        'true'
+      );
+    });
+  });
+
+  it('should not mark addons as read-only by default', () => {
+    render(
+      <FormFieldControlGroup data-testid="root" endAddon={<span>end</span>}>
+        <input data-testid="input" />
+      </FormFieldControlGroup>
+    );
+
+    expect(getRoot()).not.toHaveAttribute('data-readonly');
+
+    expect(screen.getByTestId('field-addon-end')).not.toHaveAttribute(
+      'data-readonly'
+    );
+  });
 });

--- a/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.tsx
+++ b/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroup.tsx
@@ -21,6 +21,7 @@ export const FormFieldControlGroup = forwardRef<
     variant = 'filled',
     isInvalid,
     isDisabled,
+    isReadOnly,
     children,
     className,
     startAddon,
@@ -60,6 +61,7 @@ export const FormFieldControlGroup = forwardRef<
       )}
       isInvalid={isInvalid}
       isDisabled={isDisabled}
+      data-readonly={isReadOnly || undefined}
       {...other}
       ref={ref}
     >
@@ -71,6 +73,7 @@ export const FormFieldControlGroup = forwardRef<
             isHovered,
             isInvalid,
             isDisabled,
+            isReadOnly,
             isFocusWithin,
           }}
         >

--- a/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroupContext.tsx
+++ b/packages/components/src/components/FormField/FormFieldControlGroup/FormFieldControlGroupContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 export type FormFieldControlGroupContextProps = {
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   hasStartAddon?: boolean;
   hasEndAddon?: boolean;
   isHovered?: boolean;

--- a/packages/components/src/components/FormField/FormFieldControlGroup/types.ts
+++ b/packages/components/src/components/FormField/FormFieldControlGroup/types.ts
@@ -39,6 +39,11 @@ export type FormFieldControlGroupProps = ExtendableComponentPropsWithRef<
     variant?: FormFieldControlGroupPropVariant;
     /** Whether the input is disabled. */
     isDisabled?: boolean;
+    /**
+     * Whether the input can be selected but not changed by the user.
+     * @selector [data-readonly]
+     */
+    isReadOnly?: boolean;
     /** Additional CSS-classes. */
     className?: string;
     /** Whether the input value is invalid. */

--- a/packages/components/src/components/Input/Input.test.tsx
+++ b/packages/components/src/components/Input/Input.test.tsx
@@ -80,20 +80,22 @@ describe('Input', () => {
       expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('should not render when input is disabled', () => {
+    it('should be disabled when input is disabled', () => {
       render(
         <Input {...baseProps} defaultValue="value" isDisabled isClearable />
       );
 
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
 
-    it('should not render when input is read-only', () => {
+    it('should be disabled when input is read-only', () => {
       render(
         <Input {...baseProps} defaultValue="value" isReadOnly isClearable />
       );
 
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
 
     it('should clear the input and call handlers when clicked', async () => {

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -113,7 +113,7 @@ export const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     <FormField as={TextField} {...rootProps}>
       {({ isInvalid, isRequired, isDisabled, state }) => {
         const hasValue = state.value !== '';
-        const clearButtonIsHidden = !hasValue || isDisabled || isReadOnly;
+        const clearButtonIsHidden = !hasValue;
 
         const labelProps = mergeProps<(FormFieldLabelProps | undefined)[]>(
           { isHidden: isLabelHidden, isRequired, children: label },
@@ -152,6 +152,7 @@ export const Input = forwardRef<InputRef, InputProps>((props, ref) => {
             },
             isInvalid,
             isDisabled,
+            isReadOnly,
             startAddon,
           },
           slotProps?.group

--- a/packages/components/src/components/InputNumber/InputNumber.tsx
+++ b/packages/components/src/components/InputNumber/InputNumber.tsx
@@ -152,6 +152,7 @@ export const InputNumber = forwardRef<InputNumberRef, InputNumberProps>(
               variant,
               startAddon,
               isDisabled,
+              isReadOnly,
             },
             slotProps?.group
           );

--- a/packages/components/src/components/SearchInput/SearchInput.test.tsx
+++ b/packages/components/src/components/SearchInput/SearchInput.test.tsx
@@ -81,14 +81,16 @@ describe('SearchInput', () => {
       expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('should not render when input is disabled', () => {
+    it('should be disabled when input is disabled', () => {
       render(<SearchInput {...baseProps} defaultValue="value" isDisabled />);
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
 
-    it('should not render when input is read-only', () => {
+    it('should be disabled when input is read-only', () => {
       render(<SearchInput {...baseProps} defaultValue="value" isReadOnly />);
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
 
     it('should not throw on render in modal', () => {

--- a/packages/components/src/components/SearchInput/SearchInput.tsx
+++ b/packages/components/src/components/SearchInput/SearchInput.tsx
@@ -103,7 +103,7 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
     const validationBehavior =
       props.validationBehavior ?? formValidationBehavior ?? 'aria';
 
-    const clearButtonIsHidden = state.value === '' || isDisabled || isReadOnly;
+    const clearButtonIsHidden = state.value === '';
 
     const {
       labelProps: labelPropsAria,
@@ -182,6 +182,7 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
         variant,
         isInvalid,
         isDisabled,
+        isReadOnly,
       },
       slotProps?.group
     );

--- a/packages/components/src/components/SelectNext/Select.module.css
+++ b/packages/components/src/components/SelectNext/Select.module.css
@@ -1,9 +1,3 @@
-.base[data-readonly] {
-  .chevron {
-    color: var(--kbq-states-icon-disabled);
-  }
-}
-
 /* addons */
 .addon {
   pointer-events: none;

--- a/packages/components/src/components/SelectNext/Select.tsx
+++ b/packages/components/src/components/SelectNext/Select.tsx
@@ -9,7 +9,6 @@ import {
   useControlledState,
   mergeProps,
   useElementSize,
-  clsx,
 } from '@koobiq/react-core';
 import { IconChevronDownS16 } from '@koobiq/react-icons';
 import {
@@ -184,7 +183,7 @@ function SelectInner<T extends object, M extends SelectionMode = 'single'>({
     'data-disabled': isDisabled || undefined,
     'data-readonly': isReadOnly || undefined,
     'data-required': isRequired || undefined,
-    className: clsx(s.base, className),
+    className,
     fullWidth,
     labelPlacement,
     labelAlign,
@@ -235,7 +234,6 @@ function SelectInner<T extends object, M extends SelectionMode = 'single'>({
   const clearButtonProps = mergeProps(
     {
       isClearable,
-      isDisabled: isReadOnly || isDisabled,
       onPress: handleClear,
       className: s.clearButton,
       isHidden: clearButtonIsHidden,
@@ -276,6 +274,7 @@ function SelectInner<T extends object, M extends SelectionMode = 'single'>({
       ),
       isInvalid,
       isDisabled,
+      isReadOnly,
       ref: containerRef,
     },
     otherGroup

--- a/packages/components/src/components/TagInput/TagInput.test.tsx
+++ b/packages/components/src/components/TagInput/TagInput.test.tsx
@@ -663,6 +663,33 @@ describe('TagInput', () => {
       expect(queryTag('a')).toBeInTheDocument();
     });
 
+    it('ignores Delete/Backspace on a focused tag when read-only', async () => {
+      const user = userEvent.setup();
+      const onRemove = vi.fn();
+
+      render(
+        <Wrapper
+          initialItems={seed(['one', 'two'])}
+          onRemove={onRemove}
+          isReadOnly
+        />
+      );
+
+      const firstTag = queryTag('one') as HTMLElement;
+      await user.click(getInput());
+      await user.keyboard('{Shift>}{Tab}{/Shift}');
+      await waitFor(() => expect(firstTag).toHaveFocus());
+
+      // No "Press Delete or Backspace to remove" hint for a shortcut that is off.
+      expect(firstTag).not.toHaveAttribute('aria-describedby');
+
+      await user.keyboard('{Backspace}');
+      await user.keyboard('{Delete}');
+
+      expect(onRemove).not.toHaveBeenCalled();
+      expect(queryTag('one')).toBeInTheDocument();
+    });
+
     it('keeps the remove button visible but disabled when read-only', async () => {
       const onRemove = vi.fn();
 

--- a/packages/components/src/components/TagInput/TagInput.test.tsx
+++ b/packages/components/src/components/TagInput/TagInput.test.tsx
@@ -663,6 +663,24 @@ describe('TagInput', () => {
       expect(queryTag('a')).toBeInTheDocument();
     });
 
+    it('keeps the remove button visible but disabled when read-only', async () => {
+      const onRemove = vi.fn();
+
+      render(
+        <Wrapper initialItems={seed(['a'])} onRemove={onRemove} isReadOnly />
+      );
+
+      const tag = queryTag('a') as HTMLElement;
+      const removeBtn = within(tag).getByRole('button');
+
+      expect(removeBtn).toBeInTheDocument();
+      expect(removeBtn).toBeDisabled();
+
+      await userEvent.click(removeBtn);
+      expect(onRemove).not.toHaveBeenCalled();
+      expect(queryTag('a')).toBeInTheDocument();
+    });
+
     it('disables tag selection in read-only but keeps focus navigation', async () => {
       const user = userEvent.setup();
       render(<Wrapper initialItems={seed(['one', 'two'])} isReadOnly />);
@@ -825,9 +843,16 @@ describe('TagInput', () => {
       expect(getInput()).toHaveFocus();
     });
 
-    it('is hidden when disabled even with tags', () => {
+    it('is disabled but visible when disabled with tags', () => {
       render(<Wrapper initialItems={seed(['a'])} isDisabled />);
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
+    });
+
+    it('is disabled but visible when read-only with tags', () => {
+      render(<Wrapper initialItems={seed(['a'])} isReadOnly />);
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
   });
 });

--- a/packages/components/src/components/TagInput/TagInput.tsx
+++ b/packages/components/src/components/TagInput/TagInput.tsx
@@ -167,6 +167,7 @@ export function TagInputInner<T extends object>(
       ),
       variant,
       isDisabled,
+      isReadOnly,
       startAddon,
       onMouseDown: (event) => {
         if (event.target !== event.currentTarget) return;

--- a/packages/components/src/components/TagList/TagListInner.tsx
+++ b/packages/components/src/components/TagList/TagListInner.tsx
@@ -14,6 +14,7 @@ export function TagListInner<T extends object>(props: TagListInnerProps<T>) {
     onRemove,
     className,
     isDisabled,
+    isReadOnly,
     autoFocus,
     tagListRef,
     escapeKeyBehavior,
@@ -39,6 +40,7 @@ export function TagListInner<T extends object>(props: TagListInnerProps<T>) {
       'aria-label': ariaLabel,
       className: clsx(s.base, className),
       'data-disabled': isDisabled || undefined,
+      'data-readonly': isReadOnly || undefined,
     },
     gridProps,
     { tabIndex }
@@ -54,6 +56,7 @@ export function TagListInner<T extends object>(props: TagListInnerProps<T>) {
           variant={variant}
           onRemove={onRemove}
           isDisabled={isDisabled}
+          isReadOnly={isReadOnly}
           collectionId={collectionId}
         />
       ))}

--- a/packages/components/src/components/TagList/components/TagItem/TagItem.tsx
+++ b/packages/components/src/components/TagList/components/TagItem/TagItem.tsx
@@ -48,6 +48,7 @@ export function TagItem<T extends object>(props: TagItemProps<T>) {
       key: item.key,
       onRemove,
       isDisabled: isDisabledProp,
+      isReadOnly,
       collectionId,
     },
     state,
@@ -88,17 +89,21 @@ export function TagItem<T extends object>(props: TagItemProps<T>) {
   };
 
   // Same order as the TagGroup wrapper: React Aria's props win over the
-  // defaults, the consumer's slot props win over both.
+  // defaults, the consumer's slot props win over both. The disabled state goes
+  // after React Aria's props, so an item-level `isDisabled={false}` cannot
+  // re-enable the button on a read-only list.
   const removeIconProps = allowsRemoving
     ? mergeProps<
         [
           TagRemoveButtonProps,
           TagRemoveButtonProps,
+          TagRemoveButtonProps,
           TagRemoveButtonProps | undefined,
         ]
       >(
-        { tabIndex: -1, isDisabled: isReadOnly || isDisabled },
+        { tabIndex: -1 },
         removeButtonPropsAria,
+        { isDisabled: isReadOnly || isDisabled },
         slotProps?.removeIcon
       )
     : undefined;

--- a/packages/components/src/components/TagList/components/TagItem/TagItem.tsx
+++ b/packages/components/src/components/TagList/components/TagItem/TagItem.tsx
@@ -17,6 +17,7 @@ type TagItemProps<T extends object> = {
   variant: TagListPropVariant;
   onRemove?: (keys: Set<Key>) => void;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   collectionId?: string;
 };
 
@@ -26,6 +27,7 @@ export function TagItem<T extends object>(props: TagItemProps<T>) {
     onRemove,
     state,
     isDisabled: isDisabledProp,
+    isReadOnly,
     variant: groupVariant,
     collectionId,
   } = props;
@@ -94,7 +96,11 @@ export function TagItem<T extends object>(props: TagItemProps<T>) {
           TagRemoveButtonProps,
           TagRemoveButtonProps | undefined,
         ]
-      >({ tabIndex: -1 }, removeButtonPropsAria, slotProps?.removeIcon)
+      >(
+        { tabIndex: -1, isDisabled: isReadOnly || isDisabled },
+        removeButtonPropsAria,
+        slotProps?.removeIcon
+      )
     : undefined;
 
   return (

--- a/packages/components/src/components/TagList/types.ts
+++ b/packages/components/src/components/TagList/types.ts
@@ -75,6 +75,11 @@ export type TagListInnerProps<T extends object = object> = {
   state: ListState<T>;
   /** Whether all tags are disabled by an owning composite component. */
   isDisabled?: boolean;
+  /**
+   * Whether the tags can be selected but not removed, e.g. when the owning
+   * composite component is read-only.
+   */
+  isReadOnly?: boolean;
   /** Ref to the root element. */
   tagListRef?: Ref<HTMLDivElement>;
 } & Omit<

--- a/packages/components/src/components/Textarea/components/TextareaContextConsumer/TextareaContextConsumer.tsx
+++ b/packages/components/src/components/Textarea/components/TextareaContextConsumer/TextareaContextConsumer.tsx
@@ -19,6 +19,7 @@ type TextareaContextConsumerProps = {
   isRequired?: boolean;
   isInvalid?: boolean;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
 } & Pick<
   TextareaProps,
   | 'slotProps'
@@ -46,6 +47,7 @@ export const TextareaContextConsumer = forwardRef<
     caption,
     variant,
     isDisabled,
+    isReadOnly,
     isRequired,
     slotProps,
     isLabelHidden,
@@ -91,6 +93,7 @@ export const TextareaContextConsumer = forwardRef<
       textareaRef.current?.focus();
     },
     isDisabled,
+    isReadOnly,
   };
 
   const labelProps = mergeProps<(FormFieldLabelProps | undefined)[]>(

--- a/packages/components/src/components/TimePicker/TimePicker.tsx
+++ b/packages/components/src/components/TimePicker/TimePicker.tsx
@@ -126,6 +126,7 @@ export function TimePickerRender<T extends TimeValue>(
       variant,
       isInvalid,
       isDisabled,
+      isReadOnly,
       endAddon,
     },
     slotProps?.group

--- a/packages/components/src/components/TimeRange/TimeRange.test.tsx
+++ b/packages/components/src/components/TimeRange/TimeRange.test.tsx
@@ -234,19 +234,31 @@ describe('TimeRange', () => {
         'Field',
         <TimeRange.Field key="6" aria-label="Period" isDisabled={false} />,
       ],
+    ])('should block a %s when the root is disabled', async (_, trigger) => {
+      render(
+        <TimeRange isDisabled data-testid="control">
+          {trigger}
+        </TimeRange>
+      );
+
+      await userEvent.tab();
+      expect(getTrigger()).not.toHaveFocus();
+
+      await userEvent.click(getTrigger());
+      expect(queryDialog()).not.toBeInTheDocument();
+    });
+
+    it.each([
+      ['Button', <Button key="10" isDisabled={false} />],
+      ['Link', <Link key="11" isDisabled={false} />],
+      [
+        'Field',
+        <TimeRange.Field key="12" aria-label="Period" isDisabled={false} />,
+      ],
     ])(
-      'should block a %s when the root is disabled or read-only',
+      'should not open a %s when the root is read-only',
       async (_, trigger) => {
-        const { rerender } = render(
-          <TimeRange isDisabled data-testid="control">
-            {trigger}
-          </TimeRange>
-        );
-
-        await userEvent.click(getTrigger());
-        expect(queryDialog()).not.toBeInTheDocument();
-
-        rerender(
+        render(
           <TimeRange isReadOnly data-testid="control">
             {trigger}
           </TimeRange>
@@ -254,10 +266,63 @@ describe('TimeRange', () => {
 
         await userEvent.click(getTrigger());
         expect(queryDialog()).not.toBeInTheDocument();
-        await userEvent.tab();
-        expect(getTrigger()).not.toHaveFocus();
       }
     );
+
+    it('should keep a read-only field focusable but closed', async () => {
+      render(
+        <TimeRange isReadOnly data-testid="control">
+          <TimeRange.Field aria-label="Period" />
+        </TimeRange>
+      );
+
+      await userEvent.tab();
+      expect(getTrigger()).toHaveFocus();
+
+      await userEvent.keyboard('{Enter}');
+      expect(queryDialog()).not.toBeInTheDocument();
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it.each([
+      ['isDisabled', 'data-disabled'],
+      ['isReadOnly', 'data-readonly'],
+    ] as const)(
+      'should inherit %s from a parent Form',
+      async (state, attribute) => {
+        const formProps =
+          state === 'isDisabled' ? { isDisabled: true } : { isReadOnly: true };
+
+        render(
+          <Form {...formProps}>
+            <TimeRange data-testid="control">
+              <TimeRange.Field label="Period" />
+            </TimeRange>
+          </Form>
+        );
+
+        await userEvent.click(getTrigger());
+        expect(queryDialog()).not.toBeInTheDocument();
+
+        expect(
+          getTrigger().closest('[data-slot="form-field"]')
+        ).toHaveAttribute(attribute, 'true');
+      }
+    );
+
+    it('should keep the editor closed on a read-only root with defaultOpen', () => {
+      render(
+        <TimeRange
+          isReadOnly
+          data-testid="control"
+          slotProps={{ popover: { defaultOpen: true } }}
+        >
+          <TimeRange.Field aria-label="Period" />
+        </TimeRange>
+      );
+
+      expect(queryDialog()).not.toBeInTheDocument();
+    });
 
     it.each([
       <Button key="7" isDisabled />,

--- a/packages/components/src/components/TimeRange/TimeRange.tsx
+++ b/packages/components/src/components/TimeRange/TimeRange.tsx
@@ -238,13 +238,17 @@ export function TimeRangeRender<T extends DateValue>(
     onOpenChange: slotProps?.popover?.onOpenChange,
   });
 
-  // The editor cannot be opened when the component is disabled or read-only,
-  // so the trigger's own state is neutralized instead of guarding every entry
-  // point (same approach as SelectNext).
+  // While disabled or read-only the editor stays closed: the open state is
+  // masked and every way to change it is a no-op, including a `defaultOpen`
+  // or `isOpen` passed through `slotProps.popover`.
   const state =
     isDisabled || isReadOnly
       ? {
           ...overlayState,
+          isOpen: false,
+          setOpen() {
+            return undefined;
+          },
           open() {
             return undefined;
           },
@@ -371,7 +375,7 @@ export function TimeRangeRender<T extends DateValue>(
             role: 'button',
             'aria-haspopup': 'dialog',
             'aria-disabled': isDisabled || undefined,
-            'aria-readonly': isReadOnly || undefined,
+            'data-readonly': isReadOnly || undefined,
             'data-testid': testId,
             tabIndex: isDisabled ? -1 : undefined,
           }}
@@ -421,14 +425,14 @@ export function TimeRangeRender<T extends DateValue>(
             customTimeRangeTypes={customTimeRangeTypes}
             minValue={minValue}
             maxValue={maxValue}
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled || isReadOnly}
             renderOption={renderOption}
             radioGroupProps={slotProps?.radioGroup}
           />
         </Popover.Body>
         <Popover.Footer>
           <Button
-            isDisabled={isDraftInvalid}
+            isDisabled={isDraftInvalid || isDisabled || isReadOnly}
             onPress={() => {
               handleApply();
               state.close();

--- a/packages/components/src/components/TimeRange/TimeRange.tsx
+++ b/packages/components/src/components/TimeRange/TimeRange.tsx
@@ -20,6 +20,7 @@ import {
 } from '@koobiq/react-primitives';
 
 import { Button } from '../Button';
+import { useForm } from '../Form';
 import { Popover } from '../Popover';
 import type { PopoverProps } from '../Popover';
 
@@ -162,14 +163,19 @@ export function TimeRangeRender<T extends DateValue>(
     hideRangeAsDefault = false,
     children,
     renderOption,
-    isDisabled,
-    isReadOnly,
+    isDisabled: isDisabledProp,
+    isReadOnly: isReadOnlyProp,
     className,
     style,
     'data-testid': testId,
     slotProps,
     ...other
   } = props;
+
+  const { isDisabled: formIsDisabled, isReadOnly: formIsReadOnly } = useForm();
+
+  const isDisabled = isDisabledProp ?? formIsDisabled;
+  const isReadOnly = isReadOnlyProp ?? formIsReadOnly;
 
   const groupRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement>(null);
@@ -226,11 +232,27 @@ export function TimeRangeRender<T extends DateValue>(
   // for a controlled one it always mirrors `value` as given.
   const displayValue = correction.corrected ? correction.value : committed;
 
-  const state = useOverlayTriggerState({
+  const overlayState = useOverlayTriggerState({
     isOpen: slotProps?.popover?.isOpen,
     defaultOpen: slotProps?.popover?.defaultOpen,
     onOpenChange: slotProps?.popover?.onOpenChange,
   });
+
+  // The editor cannot be opened when the component is disabled or read-only,
+  // so the trigger's own state is neutralized instead of guarding every entry
+  // point (same approach as SelectNext).
+  const state =
+    isDisabled || isReadOnly
+      ? {
+          ...overlayState,
+          open() {
+            return undefined;
+          },
+          toggle() {
+            return undefined;
+          },
+        }
+      : overlayState;
 
   const { triggerProps, overlayProps } = useOverlayTrigger(
     { type: 'dialog' },
@@ -338,30 +360,33 @@ export function TimeRangeRender<T extends DateValue>(
     slotProps?.popover
   );
 
-  const disabled = isDisabled || isReadOnly;
-
   return (
     <>
       <TimeRangeContext.Provider
-        value={{ formattedValue, isEmpty, isDisabled: disabled, groupRef }}
+        value={{ formattedValue, isEmpty, isDisabled, isReadOnly, groupRef }}
       >
         <PressResponder
           {...triggerProps}
           {...{
             role: 'button',
             'aria-haspopup': 'dialog',
-            'aria-disabled': disabled || undefined,
+            'aria-disabled': isDisabled || undefined,
+            'aria-readonly': isReadOnly || undefined,
             'data-testid': testId,
-            tabIndex: disabled ? -1 : undefined,
+            tabIndex: isDisabled ? -1 : undefined,
           }}
           onPress={(event) => {
-            if (!disabled) triggerProps.onPress?.(event);
+            if (isDisabled || isReadOnly) return;
+
+            triggerProps.onPress?.(event);
           }}
-          isDisabled={disabled}
+          isDisabled={isDisabled}
           isPressed={state.isOpen}
           ref={mergeRefs(ref, triggerRef)}
         >
-          <ButtonContext.Provider value={{ isDisabled: disabled }}>
+          <ButtonContext.Provider
+            value={{ isDisabled: isDisabled || isReadOnly }}
+          >
             {typeof children === 'function'
               ? children({ formattedValue })
               : children}

--- a/packages/components/src/components/TimeRange/components/TimeRangeContext.ts
+++ b/packages/components/src/components/TimeRange/components/TimeRangeContext.ts
@@ -7,6 +7,7 @@ type TimeRangeContextValue = {
   formattedValue: string;
   isEmpty: boolean;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   groupRef: RefObject<HTMLDivElement | null>;
 };
 

--- a/packages/components/src/components/TimeRange/components/TimeRangeField.tsx
+++ b/packages/components/src/components/TimeRange/components/TimeRangeField.tsx
@@ -138,6 +138,9 @@ export const TimeRangeField = forwardRef<
           return;
         event.preventDefault();
         controlRef.current?.focus();
+
+        if (isReadOnly) return;
+
         controlRef.current?.click();
       },
     },

--- a/packages/components/src/components/TimeRange/components/TimeRangeField.tsx
+++ b/packages/components/src/components/TimeRange/components/TimeRangeField.tsx
@@ -47,6 +47,7 @@ export const TimeRangeField = forwardRef<
     isRequired,
     isInvalid = false,
     isDisabled: isDisabledProp,
+    isReadOnly: isReadOnlyProp,
     errorMessage,
     caption,
     fullWidth,
@@ -63,6 +64,7 @@ export const TimeRangeField = forwardRef<
     formattedValue,
     isEmpty,
     isDisabled: contextDisabled,
+    isReadOnly: contextReadOnly,
     groupRef,
   } = useTimeRangeContext();
 
@@ -70,6 +72,9 @@ export const TimeRangeField = forwardRef<
 
   const isDisabled =
     contextDisabled || isDisabledProp || slotProps?.group?.isDisabled || false;
+
+  const isReadOnly =
+    contextReadOnly || isReadOnlyProp || slotProps?.group?.isReadOnly || false;
 
   const resolvedLabel = slotProps?.label?.children ?? label;
   const resolvedCaption = slotProps?.caption?.children ?? caption;
@@ -95,6 +100,7 @@ export const TimeRangeField = forwardRef<
       style,
       'data-invalid': isInvalid || undefined,
       'data-disabled': isDisabled || undefined,
+      'data-readonly': isReadOnly || undefined,
       'data-required': isRequired || undefined,
     },
     slotProps?.root
@@ -119,6 +125,7 @@ export const TimeRangeField = forwardRef<
   const groupProps = mergeProps<(FormFieldControlGroupProps | undefined)[]>(
     {
       isDisabled,
+      isReadOnly,
       isInvalid,
       endAddon: <IconChevronDownS16 className={s.addon} />,
       onMouseDown: (event) => {
@@ -173,6 +180,7 @@ export const TimeRangeField = forwardRef<
           {...groupProps}
           ref={mergeRefs(groupRef, groupProps.ref)}
           isDisabled={isDisabled}
+          isReadOnly={isReadOnly}
           startAddon={
             groupProps.startAddon != null ? (
               <FieldDecoration>{groupProps.startAddon}</FieldDecoration>

--- a/packages/components/src/components/TimeRange/types.ts
+++ b/packages/components/src/components/TimeRange/types.ts
@@ -99,6 +99,11 @@ export type TimeRangeFieldProps = {
   isRequired?: boolean;
   isInvalid?: boolean;
   isDisabled?: boolean;
+  /**
+   * Whether the field can be focused but not changed by the user.
+   * A read-only `TimeRange` parent overrides this value.
+   * @selector [data-readonly]
+   */
   isReadOnly?: boolean;
   errorMessage?: ReactNode;
   caption?: ReactNode;

--- a/packages/components/src/components/TimeRange/types.ts
+++ b/packages/components/src/components/TimeRange/types.ts
@@ -99,6 +99,7 @@ export type TimeRangeFieldProps = {
   isRequired?: boolean;
   isInvalid?: boolean;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   errorMessage?: ReactNode;
   caption?: ReactNode;
   fullWidth?: boolean;

--- a/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.test.tsx
@@ -600,7 +600,7 @@ describe('TreeSelect', () => {
     });
 
     it.each(['responsive', 'multiline'] as const)(
-      'should hide clear and tag remove actions with %s overflow',
+      'should disable clear and tag remove actions with %s overflow',
       (selectedTagsOverflow) => {
         renderTreeSelect({
           selectionMode: 'multiple',
@@ -610,8 +610,14 @@ describe('TreeSelect', () => {
           isClearable: true,
         });
 
-        expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
-        expect(within(getControl()).queryAllByRole('button')).toHaveLength(0);
+        expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+        expect(getClearButton()).toBeDisabled();
+
+        const removeButtons = within(getControl()).getAllByLabelText('Remove');
+
+        removeButtons.forEach((button) =>
+          expect(button).toHaveAttribute('data-disabled', 'true')
+        );
       }
     );
 
@@ -716,10 +722,11 @@ describe('TreeSelect', () => {
       expect(onClear).toHaveBeenCalledTimes(1);
     });
 
-    it('should be hidden when disabled', () => {
+    it('should be disabled when the control is disabled', () => {
       renderTreeSelect({ value: 1, isClearable: true, isDisabled: true });
 
-      expect(getClearButton()).toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).not.toHaveAttribute('aria-hidden', 'true');
+      expect(getClearButton()).toBeDisabled();
     });
   });
 

--- a/packages/components/src/components/TreeSelect/TreeSelect.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.tsx
@@ -239,8 +239,7 @@ export function TreeSelectInner<
     validationDetails,
   };
 
-  const clearButtonIsHidden =
-    isDisabled || isReadOnly || !state.selectedItems.length;
+  const clearButtonIsHidden = !state.selectedItems.length;
 
   const handleClear = useCallback(() => {
     if (isReadOnly) return;
@@ -320,6 +319,7 @@ export function TreeSelectInner<
       variant,
       isInvalid: isInvalidAria,
       isDisabled,
+      isReadOnly,
       ref: triggerRef,
     },
     slotProps?.group

--- a/packages/primitives/src/behaviors/useTagField.ts
+++ b/packages/primitives/src/behaviors/useTagField.ts
@@ -103,6 +103,7 @@ export type TagFieldClearButtonProps = {
 export type TagFieldTagListProps<T extends object> = {
   state: TagListState<T>;
   isDisabled: boolean | undefined;
+  isReadOnly: boolean | undefined;
   tabIndex: -1;
   onRemove:
     ((keys: Set<Key>, context?: TagListItemRemoveContext) => void) | undefined;
@@ -217,6 +218,8 @@ export function useTagField<T extends object>(
 
   const handleRemove = useCallback(
     (keys: Set<Key>, context?: TagListItemRemoveContext) => {
+      if (isDisabled || isReadOnly) return;
+
       if (
         remove(keys) &&
         (context?.source === 'press' || keys.size >= collection.size)
@@ -224,7 +227,7 @@ export function useTagField<T extends object>(
         inputRef.current?.focus({ preventScroll: true });
       }
     },
-    [collection, inputRef, remove]
+    [collection, inputRef, isDisabled, isReadOnly, remove]
   );
 
   const focusTagAt = useCallback(
@@ -262,8 +265,10 @@ export function useTagField<T extends object>(
   }, [autocompleteClose]);
 
   const handleClear = useCallback(() => {
+    if (isDisabled || isReadOnly) return;
+
     if (clear()) focusInput();
-  }, [clear, focusInput]);
+  }, [clear, focusInput, isDisabled, isReadOnly]);
 
   const collectionState = autocompleteListState ?? state;
   const collectionRef = listBoxRef ?? innerRef;
@@ -567,9 +572,7 @@ export function useTagField<T extends object>(
   const hasInputValue = inputValue !== '';
   const showCleaner = Boolean(isClearable);
 
-  const cleanerIsHidden = Boolean(
-    !showCleaner || (!hasTags && !hasInputValue) || isDisabled || isReadOnly
-  );
+  const cleanerIsHidden = Boolean(!showCleaner || (!hasTags && !hasInputValue));
 
   const clearButtonProps: TagFieldClearButtonProps = {
     isClearable: showCleaner,
@@ -581,8 +584,9 @@ export function useTagField<T extends object>(
   const tagListProps = {
     state,
     isDisabled,
+    isReadOnly,
     tabIndex: -1,
-    onRemove: isReadOnly ? undefined : handleRemove,
+    onRemove: handleRemove,
     'aria-label': ariaLabel ?? stringFormatter.format('tagListLabel'),
   } as const;
 

--- a/packages/primitives/src/behaviors/useTagListItem.ts
+++ b/packages/primitives/src/behaviors/useTagListItem.ts
@@ -67,6 +67,11 @@ export type AriaTagListItemProps = {
   collectionId?: string;
   onRemove?: (keys: Set<Key>, context?: TagListItemRemoveContext) => void;
   isDisabled?: boolean;
+  /**
+   * Whether removal is blocked while the remove affordance stays rendered:
+   * the Delete/Backspace shortcut and its screen-reader hint are turned off.
+   */
+  isReadOnly?: boolean;
 };
 
 export type TagListItemAria = {
@@ -94,7 +99,13 @@ export function useTagListItem<T extends object>(
   state: ListState<T>,
   ref: RefObject<HTMLDivElement | null>
 ): TagListItemAria {
-  const { key, collectionId, onRemove, isDisabled: isDisabledProp } = props;
+  const {
+    key,
+    collectionId,
+    onRemove,
+    isDisabled: isDisabledProp,
+    isReadOnly,
+  } = props;
 
   const rowId = useId();
   const removeButtonId = useId();
@@ -112,6 +123,10 @@ export function useTagListItem<T extends object>(
   // The remove affordance stays visible on disabled tags — the button just
   // renders disabled (state propagated via `removeButtonProps.isDisabled`).
   const allowsRemoving = !!onRemove;
+
+  // Read-only keeps the remove affordance rendered, but the keyboard shortcut
+  // and its hint are off — the key then propagates like on a non-removable tag.
+  const allowsKeyboardRemoval = allowsRemoving && !isReadOnly;
 
   const allowsSelection = !isDisabled && selectionManager.canSelectItem(key);
 
@@ -133,7 +148,7 @@ export function useTagListItem<T extends object>(
   }
 
   const description =
-    allowsRemoving &&
+    allowsKeyboardRemoval &&
     !isDisabled &&
     (modality === 'keyboard' || modality === 'virtual')
       ? stringFormatter.format('removeDescription')
@@ -236,7 +251,7 @@ export function useTagListItem<T extends object>(
       }
 
       if (event.key === 'Backspace' || event.key === 'Delete') {
-        if (!allowsRemoving) {
+        if (!allowsKeyboardRemoval) {
           event.continuePropagation();
 
           return;

--- a/packages/primitives/src/components/TextField/TextField.tsx
+++ b/packages/primitives/src/components/TextField/TextField.tsx
@@ -87,11 +87,13 @@ function TextFieldRender(
   }, []);
 
   const handleClear = useCallback(() => {
+    if (isDisabled || isReadOnly) return;
+
     setInputValue('');
 
     onClear?.();
     inputRef?.current?.focus();
-  }, [setInputValue, onClear]);
+  }, [isDisabled, isReadOnly, setInputValue, onClear]);
 
   useIsomorphicEffect(() => {
     if (!inputRef.current) return;

--- a/tools/public_api_guard/components/FormField.api.md
+++ b/tools/public_api_guard/components/FormField.api.md
@@ -68,6 +68,7 @@ export const FormFieldControlGroupContext: Context<FormFieldControlGroupContextP
 // @public (undocumented)
 export type FormFieldControlGroupContextProps = {
     isDisabled?: boolean;
+    isReadOnly?: boolean;
     hasStartAddon?: boolean;
     hasEndAddon?: boolean;
     isHovered?: boolean;
@@ -85,6 +86,7 @@ export type FormFieldControlGroupProps = ExtendableComponentPropsWithRef<{
     endAddon?: ReactNode;
     variant?: FormFieldControlGroupPropVariant;
     isDisabled?: boolean;
+    isReadOnly?: boolean;
     className?: string;
     isInvalid?: boolean;
     slotProps?: {
@@ -190,7 +192,7 @@ export const useFormFieldControlGroup: () => FormFieldControlGroupContextProps;
 
 // Warnings were encountered during analysis:
 //
-// packages/components/dist/components/FormField/FormFieldControlGroup/types.d.ts:31:9 - (ae-forgotten-export) The symbol "FormFieldAddonProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/FormField/FormFieldControlGroup/types.d.ts:36:9 - (ae-forgotten-export) The symbol "FormFieldAddonProps" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/components/TagList.api.md
+++ b/tools/public_api_guard/components/TagList.api.md
@@ -33,6 +33,7 @@ export type TagListComponent = <T extends object = object>(props: TagListProps<T
 export type TagListInnerProps<T extends object = object> = {
     state: ListState<T>;
     isDisabled?: boolean;
+    isReadOnly?: boolean;
     tagListRef?: Ref<HTMLDivElement>;
 } & Omit<TagListProps<T>, 'ref' | 'children' | 'items' | 'disabledKeys' | 'selectionMode' | 'disallowEmptySelection' | 'selectedKeys' | 'defaultSelectedKeys' | 'onSelectionChange'>;
 

--- a/tools/public_api_guard/components/TimeRange.api.md
+++ b/tools/public_api_guard/components/TimeRange.api.md
@@ -165,16 +165,16 @@ export type TimeRangeValue = {
 
 // Warnings were encountered during analysis:
 //
-// packages/components/dist/components/TimeRange/types.d.ts:61:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelPlacement" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:62:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelAlign" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:76:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:77:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:78:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:79:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:80:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:81:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:157:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:158:9 - (ae-forgotten-export) The symbol "RadioGroupProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:66:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelPlacement" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:67:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelAlign" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:81:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:82:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:83:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:84:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:85:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:86:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:162:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:163:9 - (ae-forgotten-export) The symbol "RadioGroupProps" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/components/TimeRange.api.md
+++ b/tools/public_api_guard/components/TimeRange.api.md
@@ -66,6 +66,7 @@ export type TimeRangeFieldProps = {
     isRequired?: boolean;
     isInvalid?: boolean;
     isDisabled?: boolean;
+    isReadOnly?: boolean;
     errorMessage?: ReactNode;
     caption?: ReactNode;
     fullWidth?: boolean;
@@ -164,16 +165,16 @@ export type TimeRangeValue = {
 
 // Warnings were encountered during analysis:
 //
-// packages/components/dist/components/TimeRange/types.d.ts:60:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelPlacement" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:61:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelAlign" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:75:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:76:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:77:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:78:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:79:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:80:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:156:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
-// packages/components/dist/components/TimeRange/types.d.ts:157:9 - (ae-forgotten-export) The symbol "RadioGroupProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:61:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelPlacement" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:62:5 - (ae-forgotten-export) The symbol "FormFieldPropLabelAlign" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:76:9 - (ae-forgotten-export) The symbol "FormFieldProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:77:9 - (ae-forgotten-export) The symbol "FormFieldLabelProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:78:9 - (ae-forgotten-export) The symbol "FormFieldControlGroupProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:79:9 - (ae-forgotten-export) The symbol "FormFieldSelectProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:80:9 - (ae-forgotten-export) The symbol "FormFieldCaptionProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:81:9 - (ae-forgotten-export) The symbol "FormFieldErrorProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:157:9 - (ae-forgotten-export) The symbol "PopoverProps" needs to be exported by the entry point index.d.ts
+// packages/components/dist/components/TimeRange/types.d.ts:158:9 - (ae-forgotten-export) The symbol "RadioGroupProps" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/react-primitives.api.md
+++ b/tools/public_api_guard/react-primitives.api.md
@@ -744,6 +744,7 @@ export type TagFieldTagListContainerProps = HTMLAttributes<HTMLDivElement> & {
 export type TagFieldTagListProps<T extends object> = {
     state: TagListState<T>;
     isDisabled: boolean | undefined;
+    isReadOnly: boolean | undefined;
     tabIndex: -1;
     onRemove: ((keys: Set<Key_2>, context?: TagListItemRemoveContext) => void) | undefined;
     'aria-label': string;

--- a/tools/public_api_guard/react-primitives.api.md
+++ b/tools/public_api_guard/react-primitives.api.md
@@ -223,6 +223,7 @@ export type AriaTagListItemProps = {
     collectionId?: string;
     onRemove?: (keys: Set<Key_2>, context?: TagListItemRemoveContext) => void;
     isDisabled?: boolean;
+    isReadOnly?: boolean;
 };
 
 // @public (undocumented)


### PR DESCRIPTION
### Notes

- The deprecated `Select` is intentionally left as is: it has no `isReadOnly` support, so it can't follow the new contract; a disabled `Select` still hides its clear button.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved read-only support across form controls, including date/time fields, selects, autocomplete, tag inputs, and tree selectors.
  - Read-only controls now consistently expose their state and prevent editing, clearing, removal, or opening interactive overlays.
  - Clear and remove buttons remain visible but disabled when controls are disabled or read-only.
  - Added form examples with disabled and read-only state toggles.

- **Bug Fixes**
  - Prevented actions such as clearing, tag removal, and time-range selection while read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->