### PR TITLE
feat(Resizable): support single-axis sizing (DS-5552)

### DIFF
--- a/packages/components/src/components/Resizable/Resizable.mdx
+++ b/packages/components/src/components/Resizable/Resizable.mdx
@@ -54,6 +54,23 @@ The measured size is fixed in pixels only after the first resize interaction.
 
 <Story of={Stories.IntrinsicSize} />
 
+### One dimension
+
+`size` and `defaultSize` accept a single dimension. The omitted one keeps its CSS size and is
+never written to the element, which suits elements sized by their layout in the other axis —
+a side panel stretched to the full height of its container, for example:
+
+```tsx
+<Resizable defaultSize={{ width: 320 }} minSize={{ width: 240 }}>
+  <Content />
+  <Resizable.Handle direction={[1, 0]} />
+</Resizable>
+```
+
+An axis becomes managed as soon as it's given in `size` / `defaultSize`, or resized by a handle.
+The `onResize`, `onResizeStart` and `onResizeEnd` handlers always report both dimensions,
+measured where an axis isn't managed.
+
 ## Direction
 
 `Resizable.Handle` accepts a physical `[x, y]` direction. Each axis supports `-1`, `0`, and `1`:
@@ -85,6 +102,9 @@ for geometry customization.
 Handles are focusable. Use the arrow keys to resize by one pixel, or hold <kbd>Shift</kbd> to resize
 by ten pixels. Edge handles expose the ARIA separator pattern; corner handles expose an accessible
 two-dimensional resize control.
+
+Set `disableKeyboardResize` on a handle to leave it drag-only. It also drops out of the tab order,
+unless `tabIndex` says otherwise.
 
 ## Disabled
 

--- a/packages/components/src/components/Resizable/Resizable.mdx
+++ b/packages/components/src/components/Resizable/Resizable.mdx
@@ -50,7 +50,7 @@ All values are measured in CSS pixels.
 ### Intrinsic size
 
 When both `size` and `defaultSize` are omitted, Resizable preserves its natural CSS size.
-The measured size is fixed in pixels only after the first resize interaction.
+The first resize interaction fixes the resized axes in pixels, the others keep their CSS size.
 
 <Story of={Stories.IntrinsicSize} />
 
@@ -58,18 +58,14 @@ The measured size is fixed in pixels only after the first resize interaction.
 
 `size` and `defaultSize` accept a single dimension. The omitted one keeps its CSS size and is
 never written to the element, which suits elements sized by their layout in the other axis —
-a side panel stretched to the full height of its container, for example:
-
-```tsx
-<Resizable defaultSize={{ width: 320 }} minSize={{ width: 240 }}>
-  <Content />
-  <Resizable.Handle direction={[1, 0]} />
-</Resizable>
-```
+a side panel stretched to the full height of its container, for example.
 
 An axis becomes managed as soon as it's given in `size` / `defaultSize`, or resized by a handle.
-The `onResize`, `onResizeStart` and `onResizeEnd` handlers always report both dimensions,
-measured where an axis isn't managed.
+The `onResize`, `onResizeStart` and `onResizeEnd` handlers always report both dimensions.
+An axis that isn't managed is measured once, when the resize starts. To control a single axis,
+take only that axis from the handler: passing the whole size back would manage the other one too.
+
+<Story of={Stories.OneDimension} />
 
 ## Direction
 

--- a/packages/components/src/components/Resizable/Resizable.stories.tsx
+++ b/packages/components/src/components/Resizable/Resizable.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['status:new', 'date:2026-07-16'],
+  tags: ['status:updated', 'date:2026-09-11'],
 } satisfies Meta<typeof Resizable>;
 
 export default meta;
@@ -96,6 +96,28 @@ export const IntrinsicSize: Story = {
       <Handles />
     </Resizable>
   ),
+};
+
+export const OneDimension: Story = {
+  render: function Render(args) {
+    const [width, setWidth] = useState(240);
+
+    return (
+      <div className={s.layout}>
+        <Resizable
+          {...args}
+          className={s.content}
+          size={{ width }}
+          minSize={{ width: 160 }}
+          maxSize={{ width: 400 }}
+          onResize={(size) => setWidth(size.width)}
+        >
+          <Typography>{Math.round(width)} px × 100%</Typography>
+          <Resizable.Handle className={handleClassName} direction={[1, 0]} />
+        </Resizable>
+      </div>
+    );
+  },
 };
 
 export const SingleDirection: Story = {

--- a/packages/components/src/components/Resizable/Resizable.test.tsx
+++ b/packages/components/src/components/Resizable/Resizable.test.tsx
@@ -1,4 +1,4 @@
-import { createRef, type ComponentProps } from 'react';
+import { createRef, useState, type ComponentProps } from 'react';
 
 import type * as ReactCore from '@koobiq/react-core';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -70,33 +70,6 @@ describe('Resizable', () => {
   beforeEach(() => {
     mocks.observedSize = { width: 300, height: 200 };
     vi.stubGlobal('PointerEvent', undefined);
-
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
-      function getBoundingClientRect(this: HTMLElement) {
-        const width = Number.parseFloat(this.style.width);
-        const height = Number.parseFloat(this.style.height);
-
-        const resolvedWidth = Number.isNaN(width)
-          ? mocks.observedSize.width
-          : width;
-
-        const resolvedHeight = Number.isNaN(height)
-          ? mocks.observedSize.height
-          : height;
-
-        return {
-          x: 0,
-          y: 0,
-          top: 0,
-          left: 0,
-          right: resolvedWidth,
-          bottom: resolvedHeight,
-          width: resolvedWidth,
-          height: resolvedHeight,
-          toJSON: () => ({}),
-        };
-      }
-    );
   });
 
   afterEach(() => {
@@ -315,6 +288,28 @@ describe('Resizable', () => {
     expect(getRoot().style.height).toBe('');
   });
 
+  it('keeps the omitted axis unmanaged in controlled state', () => {
+    function ControlledWidth() {
+      const [width, setWidth] = useState(300);
+
+      return (
+        <Resizable
+          data-testid="resizable"
+          size={{ width }}
+          onResize={(size) => setWidth(size.width)}
+        >
+          <Resizable.Handle data-testid="handle" direction={[1, 0]} />
+        </Resizable>
+      );
+    }
+
+    render(<ControlledWidth />);
+    drag(20, 10);
+
+    expect(getRoot()).toHaveStyle({ width: '320px' });
+    expect(getRoot().style.height).toBe('');
+  });
+
   it('keeps the managed axis when another axis is resized', () => {
     render(
       <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
@@ -328,41 +323,32 @@ describe('Resizable', () => {
   });
 
   it('disables arrow key resizing without breaking dragging', () => {
-    renderResizable([1, 0], { defaultSize: { width: 300 } });
-
     render(
       <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
         <Resizable.Handle
-          data-testid="static-handle"
+          data-testid="handle"
           direction={[1, 0]}
           disableKeyboardResize
         />
       </Resizable>
     );
 
-    const handle = screen.getByTestId('static-handle');
-    const root = handle.parentElement as HTMLElement;
+    expect(getHandle()).toHaveAttribute('tabindex', '-1');
 
-    expect(handle).toHaveAttribute('tabindex', '-1');
+    fireEvent.keyDown(getHandle(), { key: 'ArrowRight' });
 
-    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(getRoot()).toHaveStyle({ width: '300px' });
 
-    expect(root).toHaveStyle({ width: '300px' });
+    drag(20, 0);
 
-    fireEvent.mouseDown(handle, { button: 0, clientX: 10, clientY: 10 });
-    fireEvent.mouseMove(window, { button: 0, clientX: 30, clientY: 10 });
-    fireEvent.mouseUp(window, { button: 0, clientX: 30, clientY: 10 });
-
-    expect(root).toHaveStyle({ width: '320px' });
+    expect(getRoot()).toHaveStyle({ width: '320px' });
   });
 
   it('keeps the handle focusable when tabIndex is set explicitly', () => {
-    renderResizable([1, 0], { defaultSize: { width: 300 } });
-
     render(
       <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
         <Resizable.Handle
-          data-testid="static-handle"
+          data-testid="handle"
           direction={[1, 0]}
           tabIndex={0}
           disableKeyboardResize
@@ -370,10 +356,7 @@ describe('Resizable', () => {
       </Resizable>
     );
 
-    expect(screen.getByTestId('static-handle')).toHaveAttribute(
-      'tabindex',
-      '0'
-    );
+    expect(getHandle()).toHaveAttribute('tabindex', '0');
   });
 
   it('calls lifecycle callbacks with the snapshot and final size', () => {
@@ -529,6 +512,24 @@ describe('Resizable', () => {
     expect(getHandle()).not.toHaveAttribute('aria-valuenow');
     expect(getHandle()).not.toHaveAttribute('aria-orientation');
     expect(getHandle()).toHaveAttribute('aria-controls', getRoot().id);
+  });
+
+  it('does not advertise arrow keys when keyboard resizing is disabled', () => {
+    render(
+      <Resizable
+        data-testid="resizable"
+        defaultSize={{ width: 300, height: 200 }}
+      >
+        <Resizable.Handle
+          data-testid="handle"
+          direction={[1, 1]}
+          disableKeyboardResize
+        />
+      </Resizable>
+    );
+
+    expect(getHandle()).toHaveAttribute('role', 'button');
+    expect(getHandle()).not.toHaveAttribute('aria-keyshortcuts');
   });
 
   it('localizes default accessible labels', () => {

--- a/packages/components/src/components/Resizable/Resizable.test.tsx
+++ b/packages/components/src/components/Resizable/Resizable.test.tsx
@@ -280,7 +280,100 @@ describe('Resizable', () => {
 
     fireEvent.keyDown(getHandle(), { key: 'ArrowRight' });
 
-    expect(getRoot()).toHaveStyle({ width: '261px', height: '140px' });
+    // Only the resized axis becomes managed, the other one is left to CSS.
+    expect(getRoot()).toHaveStyle({ width: '261px' });
+    expect(getRoot().style.height).toBe('');
+  });
+
+  it('manages a single dimension when the size defines one axis', () => {
+    const onResize = vi.fn();
+
+    mocks.observedSize = { width: 300, height: 200 };
+
+    renderResizable([1, 0], {
+      defaultSize: { width: 300 },
+      minSize: { width: 100 },
+      maxSize: { width: 500 },
+      onResize,
+    });
+
+    expect(getRoot()).toHaveStyle({
+      width: '300px',
+      minWidth: '100px',
+      maxWidth: '500px',
+    });
+
+    expect(getRoot().style.height).toBe('');
+    expect(getRoot().style.minHeight).toBe('');
+    expect(getRoot().style.maxHeight).toBe('');
+
+    drag(25, 40);
+
+    // The callbacks still report both dimensions, measured where unmanaged.
+    expect(onResize).toHaveBeenLastCalledWith({ width: 325, height: 200 });
+    expect(getRoot()).toHaveStyle({ width: '325px' });
+    expect(getRoot().style.height).toBe('');
+  });
+
+  it('keeps the managed axis when another axis is resized', () => {
+    render(
+      <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
+        <Resizable.Handle data-testid="handle" direction={[0, 1]} />
+      </Resizable>
+    );
+
+    fireEvent.keyDown(getHandle(), { key: 'ArrowDown' });
+
+    expect(getRoot()).toHaveStyle({ width: '300px', height: '201px' });
+  });
+
+  it('disables arrow key resizing without breaking dragging', () => {
+    renderResizable([1, 0], { defaultSize: { width: 300 } });
+
+    render(
+      <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
+        <Resizable.Handle
+          data-testid="static-handle"
+          direction={[1, 0]}
+          disableKeyboardResize
+        />
+      </Resizable>
+    );
+
+    const handle = screen.getByTestId('static-handle');
+    const root = handle.parentElement as HTMLElement;
+
+    expect(handle).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+
+    expect(root).toHaveStyle({ width: '300px' });
+
+    fireEvent.mouseDown(handle, { button: 0, clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(window, { button: 0, clientX: 30, clientY: 10 });
+    fireEvent.mouseUp(window, { button: 0, clientX: 30, clientY: 10 });
+
+    expect(root).toHaveStyle({ width: '320px' });
+  });
+
+  it('keeps the handle focusable when tabIndex is set explicitly', () => {
+    renderResizable([1, 0], { defaultSize: { width: 300 } });
+
+    render(
+      <Resizable data-testid="resizable" defaultSize={{ width: 300 }}>
+        <Resizable.Handle
+          data-testid="static-handle"
+          direction={[1, 0]}
+          tabIndex={0}
+          disableKeyboardResize
+        />
+      </Resizable>
+    );
+
+    expect(screen.getByTestId('static-handle')).toHaveAttribute(
+      'tabindex',
+      '0'
+    );
   });
 
   it('calls lifecycle callbacks with the snapshot and final size', () => {

--- a/packages/components/src/components/Resizable/ResizableHandle.tsx
+++ b/packages/components/src/components/Resizable/ResizableHandle.tsx
@@ -15,6 +15,7 @@ export const ResizableHandle = polymorphicForwardRef<
   const {
     as: Tag = 'div',
     direction,
+    disableKeyboardResize,
     className,
     style: styleProp,
     tabIndex: tabIndexProp,
@@ -33,6 +34,7 @@ export const ResizableHandle = polymorphicForwardRef<
   const { handleProps } = useResizableHandle(
     {
       direction,
+      disableKeyboardResize,
       'aria-label': ariaLabelProp,
       tabIndex: tabIndexProp,
     },

--- a/packages/components/src/components/Resizable/__stories__/styles.module.css
+++ b/packages/components/src/components/Resizable/__stories__/styles.module.css
@@ -14,6 +14,15 @@
   max-inline-size: 480px;
 }
 
+.layout {
+  box-sizing: border-box;
+  border: 1px dashed var(--kbq-line-contrast-less);
+  border-radius: var(--kbq-size-s);
+  display: flex;
+  inline-size: 560px;
+  block-size: 320px;
+}
+
 .handle {
   background-color: var(--kbq-background-transparent);
   opacity: 0.25;

--- a/packages/components/src/components/Resizable/hooks/useResizable.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizable.ts
@@ -8,6 +8,7 @@ import { useElementSize } from '@koobiq/react-core';
 import type {
   ResizableHandleDirection,
   ResizableMoveEvent,
+  ResizableSize,
   ResizableSizeConstraints,
 } from './types';
 import type { ResizableState } from './useResizableState';
@@ -15,7 +16,8 @@ import { clampResizableSize } from './utils';
 
 export type ResizableContextValue = {
   rootId: string;
-  size: NonNullable<ResizableState['size']>;
+  /** The current size of both axes, measured where an axis isn't managed. */
+  size: ResizableSize;
   bounds: ResizableState['bounds'];
   isDisabled: boolean;
   activeDirection: string | null;
@@ -56,18 +58,27 @@ export const useResizable = <T extends HTMLElement = HTMLElement>(
   } = useElementSize<T>({ box: 'border-box' });
 
   const observedSize = clampResizableSize({ width, height }, bounds);
-  const currentSize = managedSize ?? observedSize;
+
+  const currentSize = clampResizableSize(
+    {
+      width: managedSize?.width ?? observedSize.width,
+      height: managedSize?.height ?? observedSize.height,
+    },
+    bounds
+  );
 
   const handleMoveStart = useCallback(
     (direction: ResizableHandleDirection) => {
       const rect = targetRef.current?.getBoundingClientRect();
 
-      startResize(
-        direction,
-        rect ? { width: rect.width, height: rect.height } : currentSize
-      );
+      // A managed axis is the source of truth, the measured one may lag behind
+      // it while the element animates to the size that was set last.
+      startResize(direction, {
+        width: managedSize?.width ?? rect?.width ?? currentSize.width,
+        height: managedSize?.height ?? rect?.height ?? currentSize.height,
+      });
     },
-    [currentSize, startResize, targetRef]
+    [currentSize, managedSize, startResize, targetRef]
   );
 
   const contextValue = useMemo<ResizableContextValue>(
@@ -98,10 +109,8 @@ export const useResizable = <T extends HTMLElement = HTMLElement>(
     ...(minSize?.height !== undefined && { minHeight: bounds.minHeight }),
     ...(Number.isFinite(bounds.maxWidth) && { maxWidth: bounds.maxWidth }),
     ...(Number.isFinite(bounds.maxHeight) && { maxHeight: bounds.maxHeight }),
-    ...(managedSize && {
-      width: managedSize.width,
-      height: managedSize.height,
-    }),
+    ...(managedSize?.width !== undefined && { width: managedSize.width }),
+    ...(managedSize?.height !== undefined && { height: managedSize.height }),
   } satisfies CSSProperties;
 
   const resizableProps = {

--- a/packages/components/src/components/Resizable/hooks/useResizable.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizable.ts
@@ -57,28 +57,24 @@ export const useResizable = <T extends HTMLElement = HTMLElement>(
     height,
   } = useElementSize<T>({ box: 'border-box' });
 
-  const observedSize = clampResizableSize({ width, height }, bounds);
-
-  const currentSize = clampResizableSize(
-    {
-      width: managedSize?.width ?? observedSize.width,
-      height: managedSize?.height ?? observedSize.height,
-    },
-    bounds
+  const currentSize = useMemo(
+    () =>
+      clampResizableSize(
+        {
+          width: managedSize?.width ?? width,
+          height: managedSize?.height ?? height,
+        },
+        bounds
+      ),
+    [managedSize?.width, managedSize?.height, width, height, bounds]
   );
 
+  // Starts from the size the handles announce. The element may lag behind a
+  // managed axis while it animates, and CSS transforms would scale its rect.
   const handleMoveStart = useCallback(
-    (direction: ResizableHandleDirection) => {
-      const rect = targetRef.current?.getBoundingClientRect();
-
-      // A managed axis is the source of truth, the measured one may lag behind
-      // it while the element animates to the size that was set last.
-      startResize(direction, {
-        width: managedSize?.width ?? rect?.width ?? currentSize.width,
-        height: managedSize?.height ?? rect?.height ?? currentSize.height,
-      });
-    },
-    [currentSize, managedSize, startResize, targetRef]
+    (direction: ResizableHandleDirection) =>
+      startResize(direction, currentSize),
+    [currentSize, startResize]
   );
 
   const contextValue = useMemo<ResizableContextValue>(

--- a/packages/components/src/components/Resizable/hooks/useResizableHandle.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizableHandle.ts
@@ -63,11 +63,9 @@ export const useResizableHandle = (
 
   // `useMove` drives both pointer and arrow keys, so dropping its key handler
   // leaves dragging intact.
-  const interactionProps = { ...moveProps };
-
-  if (disableKeyboardResize) {
-    delete interactionProps.onKeyDown;
-  }
+  const interactionProps = disableKeyboardResize
+    ? { ...moveProps, onKeyDown: undefined }
+    : moveProps;
 
   const { focusProps, isFocused, isFocusVisible } = useFocusRing({
     isTextInput: false,
@@ -107,8 +105,10 @@ export const useResizableHandle = (
   if (isCornerHandle) {
     accessibilityProps.role = 'button';
 
-    accessibilityProps['aria-keyshortcuts'] =
-      'ArrowUp ArrowDown ArrowLeft ArrowRight';
+    if (!disableKeyboardResize) {
+      accessibilityProps['aria-keyshortcuts'] =
+        'ArrowUp ArrowDown ArrowLeft ArrowRight';
+    }
   } else {
     let value = size.height;
     let minValue = bounds.minHeight;

--- a/packages/components/src/components/Resizable/hooks/useResizableHandle.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizableHandle.ts
@@ -20,6 +20,7 @@ type ResizableHandleDOMProps = DOMAttributes<HTMLElement> & {
 
 export type UseResizableHandleProps = {
   direction: ResizableHandleDirection;
+  disableKeyboardResize?: boolean;
   'aria-label'?: string;
   tabIndex?: number;
 };
@@ -29,7 +30,12 @@ export const useResizableHandle = (
   props: UseResizableHandleProps,
   state: ResizableContextValue
 ) => {
-  const { direction, 'aria-label': ariaLabel, tabIndex: tabIndexProp } = props;
+  const {
+    direction,
+    disableKeyboardResize = false,
+    'aria-label': ariaLabel,
+    tabIndex: tabIndexProp,
+  } = props;
 
   const {
     rootId,
@@ -55,6 +61,14 @@ export const useResizableHandle = (
     onMoveEnd,
   });
 
+  // `useMove` drives both pointer and arrow keys, so dropping its key handler
+  // leaves dragging intact.
+  const interactionProps = { ...moveProps };
+
+  if (disableKeyboardResize) {
+    delete interactionProps.onKeyDown;
+  }
+
   const { focusProps, isFocused, isFocusVisible } = useFocusRing({
     isTextInput: false,
     autoFocus: false,
@@ -70,7 +84,7 @@ export const useResizableHandle = (
     defaultLabel = t.format('resize height');
   }
 
-  let tabIndex = tabIndexProp ?? 0;
+  let tabIndex = tabIndexProp ?? (disableKeyboardResize ? -1 : 0);
 
   if (isDisabled) {
     tabIndex = -1;
@@ -126,7 +140,7 @@ export const useResizableHandle = (
 
   if (!isDisabled) {
     handleProps = mergeProps(
-      moveProps,
+      interactionProps,
       hoverProps,
       focusProps,
       accessibilityProps

--- a/packages/components/src/components/Resizable/hooks/useResizableState.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizableState.ts
@@ -76,9 +76,6 @@ export const useResizableState = (
     ResizableSizeConstraints
   >(controlledSize, defaultSize ?? null);
 
-  const managedSizeRef = useRef(managedSize);
-  managedSizeRef.current = managedSize;
-
   const startSizeRef = useRef<ResizableSize>({ width: 0, height: 0 });
   const lastSizeRef = useRef<ResizableSize>({ width: 0, height: 0 });
   const accumulatedRef = useRef({ x: 0, y: 0 });
@@ -95,11 +92,11 @@ export const useResizableState = (
 
       lastSizeRef.current = nextSize;
 
-      setManagedSize({
-        ...managedSizeRef.current,
+      setManagedSize((prevSize) => ({
+        ...prevSize,
         ...(x !== 0 && { width: nextSize.width }),
         ...(y !== 0 && { height: nextSize.height }),
-      });
+      }));
 
       onResize?.(nextSize);
     },

--- a/packages/components/src/components/Resizable/hooks/useResizableState.ts
+++ b/packages/components/src/components/Resizable/hooks/useResizableState.ts
@@ -18,7 +18,7 @@ import {
 } from './utils';
 
 export type ResizableState = {
-  size: ResizableSize | null;
+  size: ResizableSizeConstraints | null;
   bounds: ReturnType<typeof getResizableBounds>;
   isDisabled: boolean;
   activeDirection: string | null;
@@ -31,8 +31,8 @@ export type ResizableState = {
 };
 
 export type UseResizableStateProps = {
-  size?: ResizableSize;
-  defaultSize?: ResizableSize;
+  size?: ResizableSizeConstraints;
+  defaultSize?: ResizableSizeConstraints;
   minSize?: ResizableSizeConstraints;
   maxSize?: ResizableSizeConstraints;
   isDisabled?: boolean;
@@ -72,15 +72,39 @@ export const useResizableState = (
   );
 
   const [managedSize, setManagedSize] = useControlledState<
-    ResizableSize | null,
-    ResizableSize
-  >(controlledSize, defaultSize ?? null, onResize);
+    ResizableSizeConstraints | null,
+    ResizableSizeConstraints
+  >(controlledSize, defaultSize ?? null);
+
+  const managedSizeRef = useRef(managedSize);
+  managedSizeRef.current = managedSize;
 
   const startSizeRef = useRef<ResizableSize>({ width: 0, height: 0 });
   const lastSizeRef = useRef<ResizableSize>({ width: 0, height: 0 });
   const accumulatedRef = useRef({ x: 0, y: 0 });
   const directionRef = useRef<ResizableHandleDirection>([1, 1]);
   const [activeDirection, setActiveDirection] = useState<string | null>(null);
+
+  /**
+   * Writes the axes the interaction changes, keeping the axes that are already
+   * managed and leaving the untouched ones to CSS.
+   */
+  const applySize = useCallback(
+    (nextSize: ResizableSize, direction: ResizableHandleDirection) => {
+      const [x, y] = direction;
+
+      lastSizeRef.current = nextSize;
+
+      setManagedSize({
+        ...managedSizeRef.current,
+        ...(x !== 0 && { width: nextSize.width }),
+        ...(y !== 0 && { height: nextSize.height }),
+      });
+
+      onResize?.(nextSize);
+    },
+    [onResize, setManagedSize]
+  );
 
   const startResize = useCallback(
     (direction: ResizableHandleDirection, startSize: ResizableSize) => {
@@ -104,7 +128,8 @@ export const useResizableState = (
       accumulatedRef.current.x += event.deltaX * multiplier;
       accumulatedRef.current.y += event.deltaY * multiplier;
 
-      const [x, y] = directionRef.current;
+      const direction = directionRef.current;
+      const [x, y] = direction;
       const startSize = startSizeRef.current;
 
       const nextSize = clampResizableSize(
@@ -121,10 +146,9 @@ export const useResizableState = (
         bounds
       );
 
-      lastSizeRef.current = nextSize;
-      setManagedSize(nextSize);
+      applySize(nextSize, direction);
     },
-    [bounds, setManagedSize]
+    [applySize, bounds]
   );
 
   const endResize = useCallback(() => {

--- a/packages/components/src/components/Resizable/hooks/utils.ts
+++ b/packages/components/src/components/Resizable/hooks/utils.ts
@@ -53,10 +53,35 @@ export const clampResizableSize = (
   ),
 });
 
+/**
+ * Clamps only the axes the size defines, so an element can be managed in one
+ * dimension and keep its CSS size in the other.
+ */
 export const normalizeResizableSize = (
-  size: ResizableSize | undefined,
+  size: ResizableSizeConstraints | undefined,
   bounds: ResizableBounds
-) => (size ? clampResizableSize(size, bounds) : undefined);
+): ResizableSizeConstraints | undefined => {
+  if (!size) return undefined;
+
+  const { width, height } = size;
+
+  return {
+    ...(width !== undefined && {
+      width: clamp(
+        isFiniteNumber(width) ? width : bounds.minWidth,
+        bounds.minWidth,
+        bounds.maxWidth
+      ),
+    }),
+    ...(height !== undefined && {
+      height: clamp(
+        isFiniteNumber(height) ? height : bounds.minHeight,
+        bounds.minHeight,
+        bounds.maxHeight
+      ),
+    }),
+  };
+};
 
 export const getDirectionKey = ([x, y]: ResizableHandleDirection) =>
   `${x}:${y}`;

--- a/packages/components/src/components/Resizable/hooks/utils.ts
+++ b/packages/components/src/components/Resizable/hooks/utils.ts
@@ -37,20 +37,15 @@ export const getResizableBounds = (
 const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
 
+const clampAxis = (value: number | undefined, min: number, max: number) =>
+  clamp(isFiniteNumber(value) ? value : min, min, max);
+
 export const clampResizableSize = (
   size: ResizableSize,
   bounds: ResizableBounds
 ): ResizableSize => ({
-  width: clamp(
-    isFiniteNumber(size.width) ? size.width : bounds.minWidth,
-    bounds.minWidth,
-    bounds.maxWidth
-  ),
-  height: clamp(
-    isFiniteNumber(size.height) ? size.height : bounds.minHeight,
-    bounds.minHeight,
-    bounds.maxHeight
-  ),
+  width: clampAxis(size.width, bounds.minWidth, bounds.maxWidth),
+  height: clampAxis(size.height, bounds.minHeight, bounds.maxHeight),
 });
 
 /**
@@ -67,18 +62,10 @@ export const normalizeResizableSize = (
 
   return {
     ...(width !== undefined && {
-      width: clamp(
-        isFiniteNumber(width) ? width : bounds.minWidth,
-        bounds.minWidth,
-        bounds.maxWidth
-      ),
+      width: clampAxis(width, bounds.minWidth, bounds.maxWidth),
     }),
     ...(height !== undefined && {
-      height: clamp(
-        isFiniteNumber(height) ? height : bounds.minHeight,
-        bounds.minHeight,
-        bounds.maxHeight
-      ),
+      height: clampAxis(height, bounds.minHeight, bounds.maxHeight),
     }),
   };
 };

--- a/packages/components/src/components/Resizable/types.ts
+++ b/packages/components/src/components/Resizable/types.ts
@@ -21,10 +21,16 @@ export type {
 } from './hooks';
 
 export type ResizableBaseProps = {
-  /** The controlled size of the element, in CSS pixels. */
-  size?: ResizableSize;
-  /** The initial size of the element when uncontrolled, in CSS pixels. */
-  defaultSize?: ResizableSize;
+  /**
+   * The controlled size of the element, in CSS pixels.
+   * Omitted dimensions keep their CSS size and aren't managed.
+   */
+  size?: ResizableSizeConstraints;
+  /**
+   * The initial size of the element when uncontrolled, in CSS pixels.
+   * Omitted dimensions keep their CSS size and aren't managed.
+   */
+  defaultSize?: ResizableSizeConstraints;
   /** The minimum allowed size. Omitted dimensions default to zero. */
   minSize?: ResizableSizeConstraints;
   /** The maximum allowed size. Omitted dimensions have no upper limit. */
@@ -59,6 +65,12 @@ export type ResizableHandleBaseProps = {
    * and `1` means right/down.
    */
   direction: ResizableHandleDirection;
+  /**
+   * Whether resizing with the arrow keys is disabled. The handle also leaves
+   * the tab order, unless `tabIndex` says otherwise.
+   * @default false
+   */
+  disableKeyboardResize?: boolean;
   /** The accessible name of the handle. */
   'aria-label'?: string;
   /** Overrides the handle's position in the tab order. */

--- a/tools/public_api_guard/components/Resizable.api.md
+++ b/tools/public_api_guard/components/Resizable.api.md
@@ -18,8 +18,8 @@ export const Resizable: CompoundedComponent;
 
 // @public (undocumented)
 export type ResizableBaseProps = {
-    size?: ResizableSize;
-    defaultSize?: ResizableSize;
+    size?: ResizableSizeConstraints;
+    defaultSize?: ResizableSizeConstraints;
     minSize?: ResizableSizeConstraints;
     maxSize?: ResizableSizeConstraints;
     isDisabled?: boolean;
@@ -35,6 +35,7 @@ export type ResizableBaseProps = {
 // @public (undocumented)
 export type ResizableHandleBaseProps = {
     direction: ResizableHandleDirection;
+    disableKeyboardResize?: boolean;
     'aria-label'?: string;
     tabIndex?: number;
     className?: string;


### PR DESCRIPTION
`size` and `defaultSize` now accept a single dimension, so an element can be managed in one axis and keep its CSS size in the other. Panels stretched to the full height of their container no longer get that height frozen in pixels.

An axis becomes managed once it is given in `size` / `defaultSize` or resized by a handle; the resize handlers keep reporting both dimensions, measuring an unmanaged axis once, when the resize starts.

Also adds `disableKeyboardResize` to `Resizable.Handle` for drag-only handles, and starts a resize from the size the handles announce instead of the element rect, which drifted while the element animated and is scaled by CSS transforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resizable components now support managing width and height independently, allowing the other dimension to retain its CSS-defined size.
  * Added `disableKeyboardResize` for handles, disabling arrow-key resizing while preserving pointer dragging.
  * Handles become non-focusable by default when keyboard resizing is disabled, with `tabIndex` available to override this behavior.

* **Documentation**
  * Added guidance on one-dimensional sizing and keyboard resize controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->