### PR TITLE
docs(components): add highlighting matches examples (DS-5294)

### DIFF
--- a/packages/components/src/components/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.mdx
@@ -96,9 +96,9 @@ The following example uses the `defaultFilter` prop to filter the list of option
 
 ### Highlighting matches
 
-Use [Highlight](/docs/components-highlight--docs) to mark the part of an option that matched the query.
-Control `inputValue` so the query is available for both filtering and highlighting, and set `textValue`
-on the item so the collection keeps a plain-text label for typeahead and accessibility.
+Put [Highlight](/docs/components-highlight--docs) into `Autocomplete.ItemText` to mark the matched
+part of an option. Build the options in a `useMemo` keyed by the query — otherwise the highlight
+does not update.
 
 <Story of={Stories.HighlightingMatches} />
 

--- a/packages/components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { isString, useDebounceCallback } from '@koobiq/react-core';
 import {
@@ -276,31 +276,35 @@ export const CustomFiltering: Story = {
 
 export const HighlightingMatches: Story = {
   render: function Render() {
-    const items = [
-      { key: 'tls', name: 'TLS' },
-      { key: 'ssh', name: 'SSH' },
-      { key: 'pgp', name: 'PGP' },
-      { key: 'ipsec', name: 'IPSec' },
-      { key: 'kerberos', name: 'Kerberos' },
-    ];
-
     const { contains } = useFilter({ sensitivity: 'base' });
 
     const [inputValue, setInputValue] = useState('');
 
-    const filtered = items.filter((item) => contains(item.name, inputValue));
+    const items = useMemo(
+      () =>
+        [
+          { key: 'tls', name: 'TLS' },
+          { key: 'ssh', name: 'SSH' },
+          { key: 'pgp', name: 'PGP' },
+          { key: 'ipsec', name: 'IPSec' },
+          { key: 'kerberos', name: 'Kerberos' },
+        ].filter((item) => contains(item.name, inputValue)),
+      [contains, inputValue]
+    );
 
     return (
       <Autocomplete
+        items={items}
         label="Protocol"
-        items={filtered}
-        placeholder="Search a protocol"
         inputValue={inputValue}
         onInputChange={setInputValue}
+        placeholder="Search a protocol"
       >
         {(item) => (
           <Autocomplete.Item key={item.key} textValue={item.name}>
-            <Highlight text={item.name} query={inputValue} />
+            <Autocomplete.ItemText>
+              <Highlight text={item.name} query={inputValue} />
+            </Autocomplete.ItemText>
           </Autocomplete.Item>
         )}
       </Autocomplete>

--- a/packages/components/src/components/DropdownMenu/DropdownMenu.mdx
+++ b/packages/components/src/components/DropdownMenu/DropdownMenu.mdx
@@ -201,6 +201,14 @@ The `renderEmptyState` prop of the content replaces the default message, with an
 
 <Story of={Stories.SearchEmpty} />
 
+### Highlighting matches
+
+Put [Highlight](/docs/components-highlight--docs) into `DropdownMenu.ItemText` to mark the matched
+part of an item. Pass the query in `dependencies` of `DropdownMenu.Content` — otherwise the
+highlight does not update.
+
+<Story of={Stories.HighlightingMatches} />
+
 ## Footer
 
 The `DropdownMenu.Footer` shows text under the items. It stays in place while the

--- a/packages/components/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/components/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useBoolean } from '@koobiq/react-core';
 import {
@@ -26,6 +26,7 @@ import { Button } from '../Button';
 import { Divider } from '../Divider';
 import { EmptyState } from '../EmptyState';
 import { FlexBox } from '../FlexBox';
+import { Highlight } from '../Highlight';
 import { spacing } from '../layout';
 import { SearchInput } from '../SearchInput';
 import { SelectNext as Select } from '../SelectNext';
@@ -619,6 +620,54 @@ export const SearchEmpty: Story = {
       </DropdownMenu.Popover>
     </DropdownMenu>
   ),
+};
+
+export const HighlightingMatches: Story = {
+  render: function Render(args) {
+    const [inputValue, setInputValue] = useState('');
+
+    const items = useMemo(
+      () => [
+        { id: 'amsterdam', name: 'Amsterdam' },
+        { id: 'belgrade', name: 'Belgrade' },
+        { id: 'berlin', name: 'Berlin' },
+        { id: 'bratislava', name: 'Bratislava' },
+        { id: 'brussels', name: 'Brussels' },
+        { id: 'bucharest', name: 'Bucharest' },
+        { id: 'budapest', name: 'Budapest' },
+        { id: 'copenhagen', name: 'Copenhagen' },
+      ],
+      []
+    );
+
+    return (
+      <DropdownMenu {...args}>
+        <Button>Cities</Button>
+        <DropdownMenu.Popover>
+          <DropdownMenu.Autocomplete
+            inputValue={inputValue}
+            onInputChange={setInputValue}
+          >
+            <SearchInput />
+            <Divider disablePaddings />
+            <DropdownMenu.Content
+              items={items}
+              dependencies={[inputValue]}
+              onAction={(key) => alert(key)}
+            >
+              {(item) => (
+                <DropdownMenu.Item id={item.id} textValue={item.name}>
+                  <DropdownMenu.ItemText>
+                    <Highlight text={item.name} query={inputValue} />
+                  </DropdownMenu.ItemText>
+                </DropdownMenu.Item>
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu.Autocomplete>
+        </DropdownMenu.Popover>
+      </DropdownMenu>
+    );
+  },
 };
 
 export const DropdownFooter: Story = {

--- a/packages/components/src/components/SelectNext/Select.mdx
+++ b/packages/components/src/components/SelectNext/Select.mdx
@@ -186,22 +186,6 @@ with `defaultInputValue`, and the `onInputChange` callback is called whenever th
 
 <Story of={Stories.Searchable} />
 
-### Dependencies
-
-The collection caches a rendered item by the identity of its data object, so an item is not
-re-rendered when a value used inside the render function changes. List such values in
-`dependencies` to invalidate that cache — for example the search query when the options
-highlight it.
-
-Keep the length of the array the same between renders, otherwise the items are not
-re-rendered. To depend on a list of values, wrap it: `dependencies={[filters]}`.
-
-The same applies to `Select.Section`: it inherits `dependencies` from the Select, so the
-prop only has to be set once, on the root. A section written out in JSX can also take its
-own `dependencies`, for values only its items use.
-
-<Story of={Stories.Dependencies} />
-
 ### Minimum options for search
 
 Short lists don't need a search input. The `minOptionsThreshold` prop shows the search only when
@@ -209,6 +193,13 @@ there are at least that many options. It works together with `isSearchable`. The
 so the search is always shown.
 
 <Story of={Stories.SearchableMinOptionsThreshold} />
+
+### Highlighting matches
+
+Put [Highlight](/docs/components-highlight--docs) into `Select.ItemText` to mark the matched part of
+an option. Pass the query in `dependencies` — otherwise the highlight does not update.
+
+<Story of={Stories.HighlightingMatches} />
 
 ### Server search
 

--- a/packages/components/src/components/SelectNext/Select.stories.tsx
+++ b/packages/components/src/components/SelectNext/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 import { useBoolean } from '@koobiq/react-core';
 import {
@@ -544,30 +544,6 @@ export const Searchable: Story = {
   },
 };
 
-export const Dependencies: Story = {
-  render: function Render() {
-    const [inputValue, setInputValue] = useState('');
-
-    return (
-      <Select
-        items={options}
-        label="Attack type"
-        dependencies={[inputValue]}
-        onInputChange={setInputValue}
-        style={{ inlineSize: 200 }}
-        placeholder="Select an option"
-        isSearchable
-      >
-        {(item) => (
-          <Select.Item id={item.id} textValue={item.name}>
-            <Highlight text={item.name} query={inputValue} />
-          </Select.Item>
-        )}
-      </Select>
-    );
-  },
-};
-
 export const SearchableMinOptionsThreshold: Story = {
   render: function Render() {
     return (
@@ -593,6 +569,45 @@ export const SearchableMinOptionsThreshold: Story = {
           {(item) => <Select.Item id={item.id}>{item.name}</Select.Item>}
         </Select>
       </FlexBox>
+    );
+  },
+};
+
+export const HighlightingMatches: Story = {
+  render: function Render() {
+    const [inputValue, setInputValue] = useState('');
+
+    const items = useMemo(
+      () => [
+        { id: 1, name: 'Bruteforce' },
+        { id: 2, name: 'Complex Attack' },
+        { id: 3, name: 'DDoS' },
+        { id: 4, name: 'HIPS Alert' },
+        { id: 5, name: 'Network Attack' },
+        { id: 6, name: 'Potential Attack' },
+      ],
+      []
+    );
+
+    return (
+      <Select
+        items={items}
+        label="Attack type"
+        inputValue={inputValue}
+        dependencies={[inputValue]}
+        style={{ inlineSize: 200 }}
+        onInputChange={setInputValue}
+        placeholder="Select an option"
+        isSearchable
+      >
+        {(item) => (
+          <Select.Item id={item.id} textValue={item.name}>
+            <Select.ItemText>
+              <Highlight text={item.name} query={inputValue} />
+            </Select.ItemText>
+          </Select.Item>
+        )}
+      </Select>
     );
   },
 };

--- a/packages/components/src/components/TagAutocomplete/TagAutocomplete.mdx
+++ b/packages/components/src/components/TagAutocomplete/TagAutocomplete.mdx
@@ -79,6 +79,14 @@ Selecting a suggestion calls `onAdd(values, context)` with
 `context.source === 'suggestion'` and exposes the original item as
 `context.suggestion`.
 
+### Highlighting matches
+
+Put [Highlight](/docs/components-highlight--docs) into `TagAutocomplete.ListItem` to mark the
+matched part of a suggestion. Build the suggestions in a `useMemo` keyed by the query — otherwise
+the highlight does not update.
+
+<Story of={Stories.HighlightingMatches} />
+
 ### Create option
 
 Show a "Create" option in the list, so new values can be added with a mouse.

--- a/packages/components/src/components/TagAutocomplete/TagAutocomplete.stories.tsx
+++ b/packages/components/src/components/TagAutocomplete/TagAutocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import {
   IconCircleInfo16,
@@ -9,6 +9,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { FlexBox } from '../FlexBox';
 import { Form } from '../Form';
+import { Highlight } from '../Highlight';
 import { Button, useAsyncList, useBreakpoints, useListData } from '../index';
 import { ProgressSpinner } from '../ProgressSpinner';
 import { tagInputPropVariant } from '../TagInput';
@@ -92,6 +93,73 @@ export const Base: Story = {
         renderListItem={(item) => (
           <TagAutocomplete.ListItem key={item.id} textValue={item.name}>
             {item.name}
+          </TagAutocomplete.ListItem>
+        )}
+        fullWidth
+        disableCommitOnBlur
+      >
+        {(item) => (
+          <TagAutocomplete.Tag key={item.id} textValue={item.name}>
+            {item.name}
+          </TagAutocomplete.Tag>
+        )}
+      </TagAutocomplete>
+    );
+  },
+};
+
+export const HighlightingMatches: Story = {
+  render: function Render() {
+    const { m } = useBreakpoints();
+
+    const tagCounter = useRef(0);
+
+    const [inputValue, setInputValue] = useState('');
+
+    const list = useListData<TagItem>({
+      initialItems: [{ id: 'react', name: 'React' }],
+    });
+
+    const suggestions = useMemo(
+      () =>
+        [
+          { id: 'react', name: 'React' },
+          { id: 'typescript', name: 'TypeScript' },
+          { id: 'storybook', name: 'Storybook' },
+          { id: 'vite', name: 'Vite' },
+          { id: 'vitest', name: 'Vitest' },
+          { id: 'playwright', name: 'Playwright' },
+        ].filter((item) => containsFilter(item.name, inputValue)),
+      [inputValue]
+    );
+
+    const createTag = (name: string): TagItem => {
+      tagCounter.current += 1;
+
+      return { id: `tag-${tagCounter.current}-${name}`, name };
+    };
+
+    return (
+      <TagAutocomplete<TagItem>
+        label="Tags"
+        items={list.items}
+        listItems={suggestions}
+        onInputChange={setInputValue}
+        placeholder="Type or choose a tag"
+        style={{ inlineSize: m ? 360 : 240 }}
+        onAdd={(values, context) => {
+          if (context.source === 'suggestion') {
+            list.append(context.suggestion);
+
+            return;
+          }
+
+          list.append(...values.map(createTag));
+        }}
+        onRemove={(keys) => list.remove(...keys)}
+        renderListItem={(item) => (
+          <TagAutocomplete.ListItem key={item.id} textValue={item.name}>
+            <Highlight text={item.name} query={inputValue} />
           </TagAutocomplete.ListItem>
         )}
         fullWidth

--- a/packages/components/src/components/TreeSelect/TreeSelect.mdx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.mdx
@@ -154,20 +154,12 @@ and matches text anywhere in an item. To change how items match, pass your own
 
 <Story of={Stories.Searchable} />
 
-### Dependencies
+### Highlighting matches
 
-The collection caches a rendered item by the identity of its data object, so an item is not
-re-rendered when a value used inside the render function changes. List such values in
-`dependencies` to invalidate that cache — for example the search query when the items
-highlight it.
+Put [Highlight](/docs/components-highlight--docs) into `Tree.ItemContentText` to mark the matched
+part of an item. Pass the query in `dependencies` — otherwise the highlight does not update.
 
-Keep the length of the array the same between renders, otherwise the items are not
-re-rendered. To depend on a list of values, wrap it: `dependencies={[filters]}`.
-
-Nested `Collection` elements inherit `dependencies` from the TreeSelect, so the prop only
-has to be set once, on the root.
-
-<Story of={Stories.Dependencies} />
+<Story of={Stories.HighlightingMatches} />
 
 ### Open
 

--- a/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
+++ b/packages/components/src/components/TreeSelect/TreeSelect.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { type Key, useBoolean } from '@koobiq/react-core';
 import { IconCrosshairs16, IconFolder16 } from '@koobiq/react-icons';
@@ -601,27 +601,52 @@ export const Searchable: Story = {
   },
 };
 
-export const Dependencies: Story = {
+export const HighlightingMatches: Story = {
   render: function Render() {
+    type FileNode = { id: number; title: string; children: FileNode[] };
+
     const [inputValue, setInputValue] = useState('');
+
+    const files = useMemo<FileNode[]>(
+      () => [
+        {
+          id: 1,
+          title: 'app',
+          children: [
+            { id: 2, title: 'index.html', children: [] },
+            { id: 3, title: 'app.js', children: [] },
+          ],
+        },
+        {
+          id: 4,
+          title: 'config',
+          children: [{ id: 5, title: 'database.js', children: [] }],
+        },
+        { id: 6, title: 'README.md', children: [] },
+      ],
+      []
+    );
 
     return (
       <TreeSelect
-        items={items}
+        items={files}
         label="Project files"
+        inputValue={inputValue}
         dependencies={[inputValue]}
-        onInputChange={setInputValue}
         style={{ inlineSize: 320 }}
+        onInputChange={setInputValue}
         placeholder="Select a file"
         isSearchable
       >
-        {function renderItem(item) {
+        {function renderItem(item: FileNode) {
           return (
             <Tree.Item key={item.id} textValue={item.title}>
               <Tree.ItemContent>
-                <Highlight text={item.title} query={inputValue} />
+                <Tree.ItemContentText>
+                  <Highlight text={item.title} query={inputValue} />
+                </Tree.ItemContentText>
               </Tree.ItemContent>
-              <Collection items={item.test}>{renderItem}</Collection>
+              <Collection items={item.children}>{renderItem}</Collection>
             </Tree.Item>
           );
         }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added examples demonstrating matching-text highlighting across autocomplete, dropdown menu, select, tag autocomplete, and tree select components.
  * Highlighted search terms now update as users type in the documented examples.

* **Documentation**
  * Added guidance for using `Highlight`, providing plain-text labels with `textValue`, and updating results as queries change.
  * Clarified filtering behavior and requirements for refreshed option data.
  * Replaced dependency-focused examples with highlighting examples where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->